### PR TITLE
ciao-down: Add timeout to connect

### DIFF
--- a/testutil/ciao-down/ciao_down.go
+++ b/testutil/ciao-down/ciao_down.go
@@ -460,6 +460,7 @@ func status(ctx context.Context, errCh chan error) {
 }
 
 func connect(ctx context.Context, errCh chan error) {
+	timeout := time.NewTimer(time.Second * 30)
 	ws, err := prepareEnv(ctx)
 	if err != nil {
 		errCh <- err
@@ -494,6 +495,9 @@ func connect(ctx context.Context, errCh chan error) {
 			case <-ctx.Done():
 				errCh <- fmt.Errorf("Cancelled")
 				return
+			case <-timeout.C:
+				fmt.Println("\nCannot connect to VM, please make sure it has been started:\n\t$ ciao-down start")
+				break DONE
 			}
 
 			if sshReady(ctx, sshPort) {


### PR DESCRIPTION
Instead of looping forever, add a 30 second timeout to the connect call and
quit with a nicer error message. In cases where the VM simply has not been
started, it could me misleading to continually print waiting to boot.

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>