### PR TITLE
Add tenant create/delete and BAT tests

### DIFF
--- a/_release/bat/base_bat/base_bat_test.go
+++ b/_release/bat/base_bat/base_bat_test.go
@@ -110,22 +110,6 @@ func TestListComputeNodes(t *testing.T) {
 	}
 }
 
-// Get all tenants
-//
-// TestGetTenants calls ciao-cli tenant list -all.
-//
-// The test passes if the list of tenants defined for the cluster can
-// be retrieved, even if the list is empty.
-func TestGetTenants(t *testing.T) {
-	t.Skip("Getting all tenants not currently available")
-	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
-	_, err := bat.GetAllTenants(ctx)
-	cancelFunc()
-	if err != nil {
-		t.Fatalf("Failed to retrieve tenant list : %v", err)
-	}
-}
-
 // Confirm that the cluster is ready
 //
 // Retrieve the cluster status.

--- a/_release/bat/tenant_bat/tenant_bat.go
+++ b/_release/bat/tenant_bat/tenant_bat.go
@@ -1,0 +1,18 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package tenantbat is a placeholder package for the basic BAT tests.
+package tenantbat

--- a/_release/bat/tenant_bat/tenant_bat_test.go
+++ b/_release/bat/tenant_bat/tenant_bat_test.go
@@ -1,0 +1,165 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package tenantbat is a placeholder package for the basic BAT tests.
+package tenantbat
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ciao-project/ciao/bat"
+)
+
+const standardTimeout = time.Second * 300
+
+// Get all tenants
+//
+// TestGetTenants calls ciao-cli tenant list -all.
+//
+// The test passes if the list of tenants defined for the cluster can
+// be retrieved, even if the list is empty.
+func TestGetTenants(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
+	_, err := bat.GetAllTenants(ctx)
+	cancelFunc()
+	if err != nil {
+		t.Fatalf("Failed to retrieve tenant list : %v", err)
+	}
+}
+
+// Create a tenant
+//
+// TestCreateTenant calls ciao-cli tenant create.
+//
+// The test passes if a tenant is created successfully and can
+// be retrieved using ciao-cli tenant list -all
+func TestCreateTenant(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
+	defer cancelFunc()
+
+	config := bat.TenantConfig{
+		Name:       "CreateTenantTest",
+		SubnetBits: 4,
+	}
+
+	tenant, err := bat.CreateTenant(ctx, config)
+	if err != nil {
+		t.Fatalf("Failed to create tenant : %v", err)
+	}
+
+	if tenant.Name != config.Name {
+		t.Fatalf("Failed to create tenant")
+	}
+
+	tenants, err := bat.GetAllTenants(ctx)
+	if err != nil {
+		t.Fatalf("Failed to retrieve tenant list : %v", err)
+	}
+
+	for _, tt := range tenants.Tenants {
+		if tt.Name == config.Name {
+			return
+		}
+	}
+
+	t.Fatal("did not find new tenant in tenants list")
+}
+
+// Get a tenant config
+//
+// TestGetTenantConfig will call ciao-cli tenant list -config -for-tenant <id>
+//
+// This test passes if a tenant is successfully created and it's config
+// can be retrieved using ciao-cli tenant list -config -for-tenant <id>
+func TestGetTenantConfig(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
+	defer cancelFunc()
+
+	config := bat.TenantConfig{
+		Name:       "GetTenantConfigTest",
+		SubnetBits: 30,
+	}
+
+	tenant, err := bat.CreateTenant(ctx, config)
+	if err != nil {
+		t.Fatalf("Failed to create tenant : %v", err)
+	}
+
+	if tenant.Name != config.Name {
+		t.Fatalf("Failed to create tenant")
+	}
+
+	cfg, err := bat.GetTenantConfig(ctx, tenant.ID)
+	if err != nil {
+		t.Fatalf("Failed to retrieve tenant config: %v", err)
+	}
+
+	if cfg.Name != config.Name || cfg.SubnetBits != config.SubnetBits {
+		t.Fatalf("Failed to retrieve tenant config")
+	}
+}
+
+// Update a tenant config
+//
+// TestUpdateTenantConfig will call ciao-cli tenant update -for-tenant <id>
+//
+// This test passes if a tenant config can be updated
+func TestUpdateTenantConfig(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
+	defer cancelFunc()
+
+	config := bat.TenantConfig{
+		Name:       "UpdateTenantConfigTest",
+		SubnetBits: 30,
+	}
+
+	tenant, err := bat.CreateTenant(ctx, config)
+	if err != nil {
+		t.Fatalf("Failed to create tenant : %v", err)
+	}
+
+	if tenant.Name != config.Name {
+		t.Fatalf("Failed to create tenant")
+	}
+
+	cfg, err := bat.GetTenantConfig(ctx, tenant.ID)
+	if err != nil {
+		t.Fatalf("Failed to retrieve tenant config: %v", err)
+	}
+
+	if cfg.Name != config.Name || cfg.SubnetBits != config.SubnetBits {
+		t.Fatalf("Failed to retrieve tenant config")
+	}
+
+	config.Name = "Updated Tenant"
+	config.SubnetBits = 20
+
+	err = bat.UpdateTenant(ctx, tenant.ID, config)
+	if err != nil {
+		t.Fatalf("Failed to update tenant config: %v", err)
+	}
+
+	cfg, err = bat.GetTenantConfig(ctx, tenant.ID)
+	if err != nil {
+		t.Fatalf("Failed to retrieve tenant config: %v", err)
+	}
+
+	if cfg.Name != config.Name || cfg.SubnetBits != config.SubnetBits {
+		t.Fatalf("Failed to update tenant config: expected %s %d, got %s %d", config.Name, config.SubnetBits, cfg.Name, cfg.SubnetBits)
+	}
+}

--- a/_release/bat/tenant_bat/tenant_bat_test.go
+++ b/_release/bat/tenant_bat/tenant_bat_test.go
@@ -62,6 +62,13 @@ func TestCreateTenant(t *testing.T) {
 		t.Fatalf("Failed to create tenant : %v", err)
 	}
 
+	defer func() {
+		err = bat.DeleteTenant(ctx, tenant.ID)
+		if err != nil {
+			t.Fatalf("Failed to delete tenant: %v", err)
+		}
+	}()
+
 	if tenant.Name != config.Name {
 		t.Fatalf("Failed to create tenant")
 	}
@@ -100,6 +107,13 @@ func TestGetTenantConfig(t *testing.T) {
 		t.Fatalf("Failed to create tenant : %v", err)
 	}
 
+	defer func() {
+		err = bat.DeleteTenant(ctx, tenant.ID)
+		if err != nil {
+			t.Fatalf("Failed to delete tenant: %v", err)
+		}
+	}()
+
 	if tenant.Name != config.Name {
 		t.Fatalf("Failed to create tenant")
 	}
@@ -132,6 +146,13 @@ func TestUpdateTenantConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create tenant : %v", err)
 	}
+
+	defer func() {
+		err = bat.DeleteTenant(ctx, tenant.ID)
+		if err != nil {
+			t.Fatalf("Failed to delete tenant: %v", err)
+		}
+	}()
 
 	if tenant.Name != config.Name {
 		t.Fatalf("Failed to create tenant")

--- a/bat/compute.go
+++ b/bat/compute.go
@@ -216,22 +216,6 @@ func RunCIAOCLIAsAdminJS(ctx context.Context, tenant string, args []string,
 	return nil
 }
 
-// GetAllTenants retrieves a list of all tenants in the cluster by calling
-// ciao-cli tenant list -all. An error will be returned if the following
-// environment variables are not set; CIAO_ADMIN_CLIENT_CERT_FILE,
-// CIAO_CONTROLLER.
-func GetAllTenants(ctx context.Context) ([]*Tenant, error) {
-	var tenants []*Tenant
-
-	args := []string{"tenant", "list", "-all", "-f", "{{tojson .}}"}
-	err := RunCIAOCLIAsAdminJS(ctx, "", args, &tenants)
-	if err != nil {
-		return nil, err
-	}
-
-	return tenants, nil
-}
-
 // GetUserTenants retrieves a list of all the tenants the current user has
 // access to. An error will be returned if the following environment variables
 // are not set; CIAO_CLIENT_CERT_FILE, CIAO_CONTROLLER.

--- a/bat/tenant.go
+++ b/bat/tenant.go
@@ -1,0 +1,96 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package bat
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/ciao-project/ciao/ssntp/uuid"
+)
+
+// TenantSummary is a short form of Tenant
+type TenantSummary struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// TenantsListResponse stores a list of tenants retrieved by listTenants
+type TenantsListResponse struct {
+	Tenants []TenantSummary `json:"tenants"`
+}
+
+// TenantConfig stores the configurable attributes of a tenant.
+type TenantConfig struct {
+	Name       string `json:"name"`
+	SubnetBits int    `json:"subnet_bits"`
+}
+
+// GetAllTenants retrieves a list of all tenants in the cluster by calling
+// ciao-cli tenant list -all. An error will be returned if the following
+// environment variables are not set; CIAO_ADMIN_CLIENT_CERT_FILE,
+// CIAO_CONTROLLER.
+func GetAllTenants(ctx context.Context) (TenantsListResponse, error) {
+	var tenants TenantsListResponse
+
+	args := []string{"tenant", "list", "-all", "-f", "{{tojson .}}"}
+	err := RunCIAOCLIAsAdminJS(ctx, "", args, &tenants)
+	if err != nil {
+		return tenants, err
+	}
+
+	return tenants, nil
+}
+
+// CreateTenant creates a new tenant with the given config.
+// It calls ciao-cli tenant create.
+func CreateTenant(ctx context.Context, config TenantConfig) (TenantSummary, error) {
+	var summary TenantSummary
+
+	args := []string{"tenant", "create", "-tenant", uuid.Generate().String(), "-name", config.Name, "-subnet-bits", strconv.Itoa(config.SubnetBits), "-f", "{{tojson .}}"}
+	err := RunCIAOCLIAsAdminJS(ctx, "", args, &summary)
+
+	return summary, err
+}
+
+// UpdateTenant updates a new tenant with the given config.
+// It calls ciao-cli tenant update.
+func UpdateTenant(ctx context.Context, ID string, config TenantConfig) error {
+	args := []string{"tenant", "update", "-for-tenant", ID}
+	if config.Name != "" {
+		name := []string{"-name", config.Name}
+		args = append(args, name...)
+	}
+
+	if config.SubnetBits != 0 {
+		bits := []string{"-subnet-bits", strconv.Itoa(config.SubnetBits)}
+		args = append(args, bits...)
+	}
+
+	_, err := RunCIAOCLIAsAdmin(ctx, "", args)
+	return err
+}
+
+// GetTenantConfig retrieves the configuration for the given tenant.
+func GetTenantConfig(ctx context.Context, ID string) (TenantConfig, error) {
+	var config TenantConfig
+
+	args := []string{"tenant", "list", "-config", "-for-tenant", ID, "-f", "{{tojson .}}"}
+	err := RunCIAOCLIAsAdminJS(ctx, "", args, &config)
+
+	return config, err
+}

--- a/bat/tenant.go
+++ b/bat/tenant.go
@@ -94,3 +94,12 @@ func GetTenantConfig(ctx context.Context, ID string) (TenantConfig, error) {
 
 	return config, err
 }
+
+// DeleteTenant will delete the given tenant.
+// It calls ciao-cli tenant delete.
+func DeleteTenant(ctx context.Context, ID string) error {
+	args := []string{"tenant", "delete", "-tenant", ID}
+	_, err := RunCIAOCLIAsAdmin(ctx, "", args)
+
+	return err
+}

--- a/ciao-cli/tenant.go
+++ b/ciao-cli/tenant.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/ciao-project/ciao/ciao-controller/api"
 	"github.com/ciao-project/ciao/ciao-controller/types"
+	"github.com/ciao-project/ciao/ssntp/uuid"
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/intel/tfortools"
 )
@@ -152,6 +153,7 @@ var tenantCommand = &command{
 	SubCommands: map[string]subCommand{
 		"list":   new(tenantListCommand),
 		"update": new(tenantUpdateCommand),
+		"create": new(tenantCreateCommand),
 	},
 }
 
@@ -170,6 +172,14 @@ type tenantUpdateCommand struct {
 	name       string
 	subnetBits int
 	tenantID   string
+}
+
+type tenantCreateCommand struct {
+	Flag       flag.FlagSet
+	name       string
+	subnetBits int
+	tenantID   string
+	template   string
 }
 
 func (cmd *tenantUpdateCommand) usage(...string) {
@@ -211,6 +221,105 @@ func (cmd *tenantUpdateCommand) run(args []string) error {
 	}
 
 	return putCiaoTenantConfig(cmd.tenantID, cmd.name, cmd.subnetBits)
+}
+
+func (cmd *tenantCreateCommand) usage(...string) {
+	fmt.Fprintf(os.Stderr, `usage: ciao-cli [options] tenant create [flags]
+
+Creates a new tenant with the supplied flags
+
+The create flags are:
+
+`)
+	cmd.Flag.PrintDefaults()
+	fmt.Fprintf(os.Stderr, `
+The template passed to the -f option operates on the following struct:
+
+%s`, tfortools.GenerateUsageUndecorated(types.TenantSummary{}))
+	os.Exit(2)
+}
+
+func (cmd *tenantCreateCommand) parseArgs(args []string) []string {
+	cmd.Flag.StringVar(&cmd.tenantID, "tenant", "", "ID for new tenant")
+	cmd.Flag.IntVar(&cmd.subnetBits, "subnet-bits", 0, "Number of bits in subnet mask")
+	cmd.Flag.StringVar(&cmd.name, "name", "", "Tenant name")
+	cmd.Flag.StringVar(&cmd.template, "f", "", "Template used to format output")
+	cmd.Flag.Usage = func() { cmd.usage() }
+	cmd.Flag.Parse(args)
+	return cmd.Flag.Args()
+}
+
+func (cmd *tenantCreateCommand) run(args []string) error {
+	if !checkPrivilege() {
+		fatalf("Creating tenants is only available for privileged users")
+	}
+
+	if cmd.tenantID == "" {
+		errorf("Missing required tenantID")
+		cmd.usage()
+	}
+
+	// subnet bits must be between 4 and 30
+	if cmd.subnetBits != 0 && (cmd.subnetBits > 30 || cmd.subnetBits < 4) {
+		errorf("subnet_bits must be 4-30")
+		cmd.usage()
+	}
+
+	var t *template.Template
+	if cmd.template != "" {
+		var err error
+		t, err = tfortools.CreateTemplate("tenant-create", cmd.template, nil)
+		if err != nil {
+			fatalf(err.Error())
+		}
+	}
+
+	var req types.TenantRequest
+
+	url, err := getCiaoTenantsResource()
+	if err != nil {
+		return err
+	}
+
+	tuuid, err := uuid.Parse(cmd.tenantID)
+	if err != nil {
+		fatalf("Tenant ID must be a UUID4")
+	}
+
+	req.ID = tuuid.String()
+	req.Config = types.TenantConfig{
+		Name:       cmd.name,
+		SubnetBits: cmd.subnetBits,
+	}
+	b, err := json.Marshal(req)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	body := bytes.NewReader(b)
+
+	resp, err := sendCiaoRequest("POST", url, nil, body, api.TenantsV1)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	var summary types.TenantSummary
+	err = unmarshalHTTPResponse(resp, &summary)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	if t != nil {
+		if err := t.Execute(os.Stdout, &summary); err != nil {
+			fatalf(err.Error())
+		}
+		return nil
+	}
+
+	fmt.Printf("Tenant [%s]\n", summary.ID)
+	fmt.Printf("\tName: %s\n", summary.Name)
+
+	return nil
 }
 
 func (cmd *tenantListCommand) usage(...string) {

--- a/ciao-controller/api/api.go
+++ b/ciao-controller/api/api.go
@@ -678,6 +678,26 @@ func updateTenant(c *Context, w http.ResponseWriter, r *http.Request) (Response,
 	return Response{http.StatusNoContent, nil}, nil
 }
 
+func createTenant(c *Context, w http.ResponseWriter, r *http.Request) (Response, error) {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	var req types.TenantRequest
+	err = json.Unmarshal(body, &req)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	resp, err := c.CreateTenant(req.ID, req.Config)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	return Response{http.StatusCreated, resp}, nil
+}
+
 // Service is an interface which must be implemented by the ciao API context.
 type Service interface {
 	AddPool(name string, subnet *string, ips []string) (types.Pool, error)
@@ -699,6 +719,7 @@ type Service interface {
 	ListTenants() ([]types.TenantSummary, error)
 	ShowTenant(ID string) (types.TenantConfig, error)
 	PatchTenant(ID string, patch []byte) error
+	CreateTenant(ID string, config types.TenantConfig) (types.TenantSummary, error)
 }
 
 // Context is used to provide the services and current URL to the handlers.
@@ -826,6 +847,10 @@ func Routes(config Config, r *mux.Router) *mux.Router {
 
 	route = r.Handle("/tenants", Handler{context, listTenants, true})
 	route.Methods("GET")
+	route.HeadersRegexp("Content-Type", matchContent)
+
+	route = r.Handle("/tenants", Handler{context, createTenant, true})
+	route.Methods("POST")
 	route.HeadersRegexp("Content-Type", matchContent)
 
 	route = r.Handle("/tenants/{tenant:"+uuid.UUIDRegex+"}", Handler{context, showTenant, true})

--- a/ciao-controller/api/api_test.go
+++ b/ciao-controller/api/api_test.go
@@ -188,6 +188,14 @@ var tests = []test{
 		http.StatusCreated,
 		`{"id":"093ae09b-f653-464e-9ae6-5ae28bd03a22","name":"New Tenant","links":[{"rel":"self","href":"/tenants/093ae09b-f653-464e-9ae6-5ae28bd03a22"}]}`,
 	},
+	{
+		"DELETE",
+		"/tenants/093ae09b-f653-464e-9ae6-5ae28bd03a22",
+		"",
+		fmt.Sprintf("application/%s", TenantsV1),
+		http.StatusNoContent,
+		"null",
+	},
 }
 
 type testCiaoService struct{}
@@ -379,6 +387,10 @@ func (ts testCiaoService) CreateTenant(ID string, config types.TenantConfig) (ty
 	summary.Links = append(summary.Links, link)
 
 	return summary, nil
+}
+
+func (ts testCiaoService) DeleteTenant(string) error {
+	return nil
 }
 
 func TestResponse(t *testing.T) {

--- a/ciao-controller/api/api_test.go
+++ b/ciao-controller/api/api_test.go
@@ -180,6 +180,14 @@ var tests = []test{
 		http.StatusNoContent,
 		"null",
 	},
+	{
+		"POST",
+		"/tenants",
+		`{"id":"093ae09b-f653-464e-9ae6-5ae28bd03a22","config":{"name":"New Tenant","subnet_bits":4}}`,
+		fmt.Sprintf("application/%s", TenantsV1),
+		http.StatusCreated,
+		`{"id":"093ae09b-f653-464e-9ae6-5ae28bd03a22","name":"New Tenant","links":[{"rel":"self","href":"/tenants/093ae09b-f653-464e-9ae6-5ae28bd03a22"}]}`,
+	},
 }
 
 type testCiaoService struct{}
@@ -355,6 +363,22 @@ func (ts testCiaoService) ShowTenant(ID string) (types.TenantConfig, error) {
 
 func (ts testCiaoService) PatchTenant(string, []byte) error {
 	return nil
+}
+
+func (ts testCiaoService) CreateTenant(ID string, config types.TenantConfig) (types.TenantSummary, error) {
+	summary := types.TenantSummary{
+		ID:   ID,
+		Name: config.Name,
+	}
+
+	ref := fmt.Sprintf("/tenants/%s", summary.ID)
+	link := types.Link{
+		Rel:  "self",
+		Href: ref,
+	}
+	summary.Links = append(summary.Links, link)
+
+	return summary, nil
 }
 
 func TestResponse(t *testing.T) {

--- a/ciao-controller/client_wrapper_test.go
+++ b/ciao-controller/client_wrapper_test.go
@@ -272,3 +272,7 @@ func (client *ssntpClientWrapper) sendAndDelEventChan(cmd ssntp.Event) {
 	}
 	client.EventChansLock.Unlock()
 }
+
+func (client *ssntpClientWrapper) RemoveInstance(ID string) {
+	client.realClient.RemoveInstance(ID)
+}

--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -107,7 +107,13 @@ func (c *controller) confirmTenantRaw(tenantID string) error {
 		return nil
 	}
 
-	tenant, err = c.ds.AddTenant(tenantID)
+	// if we are adding tenant this way, we need to use defaults
+	config := types.TenantConfig{
+		Name:       "",
+		SubnetBits: 24,
+	}
+
+	tenant, err = c.ds.AddTenant(tenantID, config)
 	if err != nil {
 		return err
 	}

--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ciao-project/ciao/ciao-controller/types"
 	"github.com/ciao-project/ciao/payloads"
+	"github.com/golang/glog"
 	"github.com/pkg/errors"
 )
 
@@ -71,6 +72,48 @@ func (c *controller) stopInstance(instanceID string) error {
 
 	go c.client.StopInstance(instanceID, i.NodeID)
 	return nil
+}
+
+// delete an instance, wait for the deleted event.
+func (c *controller) deleteInstanceSync(instanceID string) error {
+	wait := make(chan struct{})
+
+	i, err := c.ds.GetInstance(instanceID)
+	if err != nil {
+		return err
+	}
+
+	err = c.deleteInstance(instanceID)
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		i.StateChange.L.Lock()
+		for {
+			i.StateLock.RLock()
+			if i.State == payloads.Deleted || i.State == payloads.Hung {
+				break
+			}
+			glog.V(2).Infof("waiting for %s to be deleted", i.ID)
+			i.StateLock.RUnlock()
+			i.StateChange.Wait()
+		}
+
+		i.StateLock.RUnlock()
+		i.StateChange.L.Unlock()
+
+		glog.V(2).Infof("%s is hung or deleted", i.ID)
+		close(wait)
+	}()
+
+	select {
+	case <-wait:
+		return nil
+	case <-time.After(2 * time.Minute):
+		transitionInstanceState(i, payloads.Hung)
+		return fmt.Errorf("timeout waiting for delete")
+	}
 }
 
 func (c *controller) deleteInstance(instanceID string) error {

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -107,7 +107,13 @@ func addFakeCNCI(tenant *types.Tenant) (*types.Instance, error) {
 func addTestTenant() (tenant *types.Tenant, err error) {
 	/* add a new tenant */
 	tuuid := uuid.Generate()
-	tenant, err = ctl.ds.AddTenant(tuuid.String())
+
+	config := types.TenantConfig{
+		Name:       "controller test tenant",
+		SubnetBits: 24,
+	}
+
+	tenant, err = ctl.ds.AddTenant(tuuid.String(), config)
 	if err != nil {
 		return
 	}
@@ -131,7 +137,13 @@ func addTestTenant() (tenant *types.Tenant, err error) {
 func addTestTenantNoCNCI() (tenant *types.Tenant, err error) {
 	/* add a new tenant */
 	tuuid := uuid.Generate()
-	tenant, err = ctl.ds.AddTenant(tuuid.String())
+
+	config := types.TenantConfig{
+		Name:       "controller test tenant no CNCI",
+		SubnetBits: 24,
+	}
+
+	tenant, err = ctl.ds.AddTenant(tuuid.String(), config)
 	if err != nil {
 		return
 	}
@@ -149,7 +161,12 @@ func addTestTenantNoCNCI() (tenant *types.Tenant, err error) {
 
 func addComputeTestTenant() (tenant *types.Tenant, err error) {
 	/* add a new tenant */
-	tenant, err = ctl.ds.AddTenant(testutil.ComputeUser)
+	config := types.TenantConfig{
+		Name:       "compute test tenant",
+		SubnetBits: 24,
+	}
+
+	tenant, err = ctl.ds.AddTenant(testutil.ComputeUser, config)
 	if err != nil {
 		return
 	}

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -2065,6 +2065,28 @@ func TestUpdateTenant(t *testing.T) {
 	}
 }
 
+func TestCreateTenant(t *testing.T) {
+	config := types.TenantConfig{
+		Name:       "createTenant",
+		SubnetBits: 21,
+	}
+
+	ID := uuid.Generate()
+
+	summary, err := ctl.CreateTenant(ID.String(), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if summary.Name != "createTenant" || summary.ID != ID.String() {
+		t.Fatal(err)
+	}
+
+	if len(summary.Links) != 1 {
+		t.Fatal("Link not built correctly")
+	}
+}
+
 var ctl *controller
 var server *testutil.SsntpTestServer
 var wrappedClient *ssntpClientWrapper

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -98,6 +98,7 @@ type persistentStore interface {
 	releaseTenantIP(tenantID string, subnetInt int, rest int) (err error)
 	claimTenantIP(tenantID string, subnetInt int, rest int) (err error)
 	updateTenant(tenant *types.Tenant) error
+	deleteTenant(tenantID string) error
 
 	// interfaces related to instances
 	getInstances() (instances []*types.Instance, err error)
@@ -342,6 +343,23 @@ func (ds *Datastore) AddTenant(id string, config types.TenantConfig) (*types.Ten
 	return &t.Tenant, nil
 }
 
+// DeleteTenant removes a tenant from the datastore.
+// It is the responsibility of the caller to ensure all tenant artifacts
+// are removed first.
+func (ds *Datastore) DeleteTenant(ID string) error {
+	ds.tenantsLock.Lock()
+	defer ds.tenantsLock.Unlock()
+
+	_, ok := ds.tenants[ID]
+	if !ok {
+		return ErrNoTenant
+	}
+
+	delete(ds.tenants, ID)
+
+	return ds.db.deleteTenant(ID)
+}
+
 func (ds *Datastore) getTenant(id string) (*tenant, error) {
 	// check cache first
 	ds.tenantsLock.RLock()
@@ -506,6 +524,15 @@ func (ds *Datastore) GetWorkload(tenantID string, ID string) (types.Workload, er
 // GetWorkloads retrieves the list of workloads for a particular tenant.
 // if there are any public workloads, they will be included in the returned list.
 func (ds *Datastore) GetWorkloads(tenantID string) ([]types.Workload, error) {
+	return ds.getWorkloads(tenantID, true)
+}
+
+// GetTenantWorkloads retrieves a list of private workloads.
+func (ds *Datastore) GetTenantWorkloads(tenantID string) ([]types.Workload, error) {
+	return ds.getWorkloads(tenantID, false)
+}
+
+func (ds *Datastore) getWorkloads(tenantID string, includePublic bool) ([]types.Workload, error) {
 	var workloads []types.Workload
 
 	// check the cache first
@@ -514,10 +541,12 @@ func (ds *Datastore) GetWorkloads(tenantID string) ([]types.Workload, error) {
 
 	// get any public workloads. These are part of our
 	// dummy tenant "public".
-	public, ok := ds.tenants["public"]
-	if ok {
-		for _, wl := range public.workloads {
-			workloads = append(workloads, wl)
+	if includePublic {
+		public, ok := ds.tenants["public"]
+		if ok {
+			for _, wl := range public.workloads {
+				workloads = append(workloads, wl)
+			}
 		}
 	}
 

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -139,7 +139,13 @@ users:
 func addTestTenant() (tenant *types.Tenant, err error) {
 	/* add a new tenant */
 	tuuid := uuid.Generate()
-	tenant, err = ds.AddTenant(tuuid.String())
+
+	config := types.TenantConfig{
+		Name:       "",
+		SubnetBits: 24,
+	}
+
+	tenant, err = ds.AddTenant(tuuid.String(), config)
 	if err != nil {
 		return
 	}
@@ -232,7 +238,12 @@ func addTestInstanceStats(t *testing.T) ([]*types.Instance, payloads.Stat) {
 func BenchmarkGetTenantNoCache(b *testing.B) {
 	/* add a new tenant */
 	tuuid := uuid.Generate().String()
-	_, err := ds.AddTenant(tuuid)
+	config := types.TenantConfig{
+		Name:       "",
+		SubnetBits: 24,
+	}
+
+	_, err := ds.AddTenant(tuuid, config)
 	if err != nil {
 		b.Error(err)
 	}
@@ -249,7 +260,12 @@ func BenchmarkGetTenantNoCache(b *testing.B) {
 func BenchmarkAllocateTenantIP(b *testing.B) {
 	/* add a new tenant */
 	tuuid := uuid.Generate().String()
-	_, err := ds.AddTenant(tuuid)
+	config := types.TenantConfig{
+		Name:       "",
+		SubnetBits: 24,
+	}
+
+	_, err := ds.AddTenant(tuuid, config)
 	if err != nil {
 		b.Error(err)
 	}
@@ -275,7 +291,12 @@ func BenchmarkGetAllInstances(b *testing.B) {
 func TestTenantCreate(t *testing.T) {
 	/* add a new tenant */
 	tuuid := uuid.Generate()
-	_, err := ds.AddTenant(tuuid.String())
+	config := types.TenantConfig{
+		Name:       "",
+		SubnetBits: 24,
+	}
+
+	_, err := ds.AddTenant(tuuid.String(), config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -992,6 +992,23 @@ func TestUpdateTenant(t *testing.T) {
 	}
 }
 
+func TestDeleteTenant(t *testing.T) {
+	tenant, err := addTestTenant()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ds.DeleteTenant(tenant.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testTenant, err := ds.GetTenant(tenant.ID)
+	if err == nil || testTenant != nil {
+		t.Fatal("Tenant not deleted")
+	}
+}
+
 func TestHandleTraceReport(t *testing.T) {
 	trace := payloads.Trace{
 		Frames: createTestFrameTraces("test"),

--- a/ciao-controller/internal/datastore/memorydb.go
+++ b/ciao-controller/internal/datastore/memorydb.go
@@ -246,3 +246,8 @@ func (db *MemoryDB) updateInstance(instance *types.Instance) error {
 func (db *MemoryDB) updateTenant(tenant *types.Tenant) error {
 	return nil
 }
+
+func (db *MemoryDB) deleteTenant(tenantID string) error {
+	delete(db.tenants, tenantID)
+	return nil
+}

--- a/ciao-controller/internal/datastore/sqlite3db_test.go
+++ b/ciao-controller/internal/datastore/sqlite3db_test.go
@@ -1227,3 +1227,40 @@ func TestSQLiteDBUpdateTenant(t *testing.T) {
 
 	db.disconnect()
 }
+
+func TestSQLiteDBDeleteTenant(t *testing.T) {
+	db, err := getPersistentStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tenantID := uuid.Generate().String()
+	config := types.TenantConfig{
+		Name:       "name1",
+		SubnetBits: 24,
+	}
+
+	err = db.addTenant(tenantID, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = db.updateQuotas(tenantID, []types.QuotaDetails{{Name: "test-quota-name", Value: 10}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = db.deleteTenant(tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tenant, err := db.getTenant(tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if tenant != nil {
+		t.Fatal("Tenant Delete not successful")
+	}
+}

--- a/ciao-controller/tenants.go
+++ b/ciao-controller/tenants.go
@@ -15,9 +15,11 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/ciao-project/ciao/ciao-controller/types"
+	"github.com/ciao-project/ciao/ssntp/uuid"
 )
 
 func (c *controller) ListTenants() ([]types.TenantSummary, error) {
@@ -68,4 +70,40 @@ func (c *controller) ShowTenant(tenantID string) (types.TenantConfig, error) {
 func (c *controller) PatchTenant(tenantID string, patch []byte) error {
 	// we need to update through datastore.
 	return c.ds.JSONPatchTenant(tenantID, patch)
+}
+
+func (c *controller) CreateTenant(tenantID string, config types.TenantConfig) (types.TenantSummary, error) {
+	// tenant ID must be a UUID4
+	tuuid, err := uuid.Parse(tenantID)
+	if err != nil {
+		return types.TenantSummary{}, err
+	}
+
+	// SubnetBits must be between 4 and 30
+	if config.SubnetBits == 0 {
+		config.SubnetBits = 24
+	} else {
+		if config.SubnetBits < 4 || config.SubnetBits > 30 {
+			return types.TenantSummary{}, errors.New("subnet bits must be between 4 and 30")
+		}
+	}
+
+	tenant, err := c.ds.AddTenant(tuuid.String(), config)
+	if err != nil {
+		return types.TenantSummary{}, err
+	}
+
+	ts := types.TenantSummary{
+		ID:   tenant.ID,
+		Name: tenant.Name,
+	}
+
+	ref := fmt.Sprintf("%s/tenants/%s", c.apiURL, tenant.ID)
+	link := types.Link{
+		Rel:  "self",
+		Href: ref,
+	}
+	ts.Links = append(ts.Links, link)
+
+	return ts, nil
 }

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -169,6 +169,12 @@ type TenantsListResponse struct {
 	Tenants []TenantSummary `json:"tenants"`
 }
 
+// TenantRequest contains information for creating a new tenant.
+type TenantRequest struct {
+	ID     string       `json:"id"`
+	Config TenantConfig `json:"config"`
+}
+
 // LogEntry stores information about events.
 type LogEntry struct {
 	Timestamp time.Time `json:"time_stamp"`

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -112,21 +112,22 @@ type WorkloadRequest struct {
 
 // Instance contains information about an instance of a workload.
 type Instance struct {
-	ID         string        `json:"instance_id"`
-	TenantID   string        `json:"tenant_id"`
-	State      string        `json:"instance_state"`
-	WorkloadID string        `json:"workload_id"`
-	NodeID     string        `json:"node_id"`
-	MACAddress string        `json:"mac_address"`
-	VnicUUID   string        `json:"vnic_uuid"`
-	Subnet     string        `json:"subnet"`
-	IPAddress  string        `json:"ip_address"`
-	SSHIP      string        `json:"ssh_ip"`
-	SSHPort    int           `json:"ssh_port"`
-	CNCI       bool          `json:"-"`
-	CreateTime time.Time     `json:"-"`
-	Name       string        `json:"name"`
-	StateLock  *sync.RWMutex `json:"-"`
+	ID          string        `json:"instance_id"`
+	TenantID    string        `json:"tenant_id"`
+	State       string        `json:"instance_state"`
+	WorkloadID  string        `json:"workload_id"`
+	NodeID      string        `json:"node_id"`
+	MACAddress  string        `json:"mac_address"`
+	VnicUUID    string        `json:"vnic_uuid"`
+	Subnet      string        `json:"subnet"`
+	IPAddress   string        `json:"ip_address"`
+	SSHIP       string        `json:"ssh_ip"`
+	SSHPort     int           `json:"ssh_port"`
+	CNCI        bool          `json:"-"`
+	CreateTime  time.Time     `json:"-"`
+	Name        string        `json:"name"`
+	StateLock   *sync.RWMutex `json:"-"`
+	StateChange *sync.Cond    `json:"-"`
 }
 
 // SortedInstancesByID implements sort.Interface for Instance by ID string

--- a/payloads/stats.go
+++ b/payloads/stats.go
@@ -142,6 +142,12 @@ const (
 	ExitFailed = "exit_failed"
 	// ExitPaused is not currently used
 	ExitPaused = "exit_paused"
+
+	// Deleted indicates that an instance has been successfully deleted.
+	Deleted = "deleted"
+
+	// Hung indicates that an instance is not responding to commands.
+	Hung = "hung"
 )
 
 // Init initialises instances of the Stat structure.


### PR DESCRIPTION
Add tenant create and delete support. Tenant create will create a new tenant with a given config. Tenant delete will remove a tenant and all it's associated objects, including instances, workloads, images, storage, and external IPs.

add some BAT tests to exercise our new tenant APIs. 

Fixes: #1435 