### PR TITLE
ciao-project: Cleanup all remaining references to 01org/ciao

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,26 +47,26 @@ Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>
 
 We accept github pull requests.
 
-If you want to work on github.com/01org/ciao and your fork on the same workstation you will need to use multiple GOPATHs.  Assuming this is the case
+If you want to work on github.com/ciao-project/ciao and your fork on the same workstation you will need to use multiple GOPATHs.  Assuming this is the case
 
 1. Open a terminal
-2. mkdir -p ~/go-fork/src/github.com/01org (replacing go-fork with your preferred location)
+2. mkdir -p ~/go-fork/src/github.com/ciao-project (replacing go-fork with your preferred location)
 3. export GOPATH=~/go-fork
-4. cd $GOPATH/src/github.com/01org
+4. cd $GOPATH/src/github.com/ciao-project
 5. git clone https://github.com/GITHUB-USERNAME/ciao.git (replace GITHUB-USERNAME with your username)
 6. cd ciao
 7. go install ./...
 
-Once you've finished making your changes push them to your fork and send the PR via the github UI.  If you don't need to maintain the github.com/01org/ciao repo and your fork on the same workstation you can skip steps 2 and 3.
+Once you've finished making your changes push them to your fork and send the PR via the github UI.  If you don't need to maintain the github.com/ciao-project/ciao repo and your fork on the same workstation you can skip steps 2 and 3.
 
 ## Quality Controls
 
 We request you give quality assurance some consideration by:
 * Adding go unit tests for changes where it makes sense.
 * Using our [test-cases](https://github.com/ciao-project/ciao/tree/master/test-cases) package to run unit tests because a simple ```gotest ./...``` can result in multiple packages' unit tests running in parallel which may be unsafe.  Simply replace ```go test``` with ```test-cases``` in your workflow.
-* Running basic cluster acceptance tests which are available in [_release/bat](https://github.com/ciao-project/ciao/tree/master/_release/bat) and are most easily run inside a [singlevm](https://github.com/01org/ciao/tree/master/testutil/singlevm) test environment, but may also be run on a hardware cluster which has your code installed/configured/running.  In some cases it will be necessary to test on real hardware, but in many a virtual cluster is an easy and fully sufficient path to test.
-* Adding BAT tests for changes where it makes sense.  The BAT tests themselves are implemented in go in the [bat package](https://github.com/ciao-project/ciao/tree/master/bat), which is essentially a wrapper/driver around ciao-cli.  Both the [bat package](https://github.com/01org/ciao/tree/master/bat) and [BAT tests](https://github.com/01org/ciao/tree/master/_release/bat) are easy to extend.
-* Enabling [Travis CI](https://travis-ci.org/01org/ciao) on your github fork of Ciao to get continuous integration feedback on your dev/test branches. We have thresholds on code coverage tracked by [coveralls](https://coveralls.io/github/01org/ciao) which you will see reported once you submit your pull request.
+* Running basic cluster acceptance tests which are available in [_release/bat](https://github.com/ciao-project/ciao/tree/master/_release/bat) and are most easily run inside a [singlevm](https://ciao-project.github.io/developer.html) test environment, but may also be run on a hardware cluster which has your code installed/configured/running.  In some cases it will be necessary to test on real hardware, but in many a virtual cluster is an easy and fully sufficient path to test.
+* Adding BAT tests for changes where it makes sense.  The BAT tests themselves are implemented in go in the [bat package](https://github.com/ciao-project/ciao/tree/master/bat), which is essentially a wrapper/driver around ciao-cli.  Both the [bat package](https://github.com/ciao-project/ciao/tree/master/bat) and [BAT tests](https://github.com/ciao-project/ciao/tree/master/_release/bat) are easy to extend.
+* Enabling [Travis CI](https://travis-ci.org/ciao-project/ciao) on your github fork of Ciao to get continuous integration feedback on your dev/test branches. We have thresholds on code coverage tracked by [coveralls](https://coveralls.io/github/ciao-project/ciao) which you will see reported once you submit your pull request.
 
 ## Issue tracking
 
@@ -81,9 +81,6 @@ the problem and work toward resolution.
 
 For feature requests we're also using github issues, with the label
 "enhancement".
-
-Our github bug/enhancement backlog and work queue are tracked in a
-[Ciao waffle.io kanban](https://waffle.io/01org/ciao).
 
 ## Closing issues
 

--- a/_release/ciao-release/main.go
+++ b/_release/ciao-release/main.go
@@ -28,7 +28,7 @@ import (
 	"time"
 )
 
-const repoOwner = "01org"
+const repoOwner = "ciao-project"
 const repo = "ciao"
 
 var rcSHA = flag.String("head", "", "The sha of the release candidate")

--- a/ciao-vendor/ciao-vendor.go
+++ b/ciao-vendor/ciao-vendor.go
@@ -402,8 +402,8 @@ func computeSubPackages(deps piList) map[string][]*subPackage {
 // breakage in a package we're not interested in would break
 // ciao-vendor
 //
-// We can't just go get github.com/01org/ciao this would pull down
-// the dependencies of the master version of ciao's depdendencies
+// We can't just go get github.com/ciao-project/ciao as this would pull
+// down the dependencies of the master version of ciao's depdendencies
 // which is not what we want.  This might miss some dependencies
 // which have been deleted from the master branch of ciao's
 // dependencies.


### PR DESCRIPTION
This commit removes the last few references to 01org/ciao.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>