### PR TITLE
vfio: Add ability to pass VFIO devices to qemu

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -591,6 +591,32 @@ func (blkdev BlockDevice) QemuParams(config *Config) []string {
 	return qemuParams
 }
 
+// VFIODevice represents a qemu vfio device meant for direct access by guest OS.
+type VFIODevice struct {
+	// Bus-Device-Function of device
+	BDF string
+}
+
+// Valid returns true if the VFIODevice structure is valid and complete.
+func (vfioDev VFIODevice) Valid() bool {
+	if vfioDev.BDF == "" {
+		return false
+	}
+
+	return true
+}
+
+// QemuParams returns the qemu parameters built out of this vfio device.
+func (vfioDev VFIODevice) QemuParams(config *Config) []string {
+	var qemuParams []string
+
+	deviceParam := fmt.Sprintf("vfio-pci,host=%s", vfioDev.BDF)
+	qemuParams = append(qemuParams, "-device")
+	qemuParams = append(qemuParams, deviceParam)
+
+	return qemuParams
+}
+
 // RTCBaseType is the qemu RTC base time type.
 type RTCBaseType string
 

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -217,6 +217,16 @@ func TestAppendDeviceBlock(t *testing.T) {
 	testAppend(blkdev, deviceBlockString, t)
 }
 
+var deviceVFIOString = "-device vfio-pci,host=02:10.0"
+
+func TestAppendDeviceVFIO(t *testing.T) {
+	vfioDevice := VFIODevice{
+		BDF: "02:10.0",
+	}
+
+	testAppend(vfioDevice, deviceVFIOString, t)
+}
+
 func TestAppendEmptyDevice(t *testing.T) {
 	device := SerialDevice{}
 


### PR DESCRIPTION
VFIO is meant for exposing exposing direct device access
to the virtual machine.
Add ability to append VFIO devices to qemu command line.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>