### PR TITLE
ciao-controller: Make CNCI volume ephemeral

### DIFF
--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -2464,7 +2464,7 @@ users:
 	storage := types.StorageResource{
 		ID:         "",
 		Bootable:   true,
-		Ephemeral:  false,
+		Ephemeral:  true,
 		SourceType: types.ImageService,
 		SourceID:   "4e16e743-265a-4bf2-9fd1-57ada0b28904",
 		Internal:   true,


### PR DESCRIPTION
When a CNCI is deleted the volume should not be leaked.

Fixes: #1446

Signed-off-by: Rob Bradford <robert.bradford@intel.com>