### PR TITLE
ciao-deploy: Allow overriding name controller is reachable with

### DIFF
--- a/ciao-deploy/cmd/setup.go
+++ b/ciao-deploy/cmd/setup.go
@@ -120,7 +120,7 @@ func init() {
 	setupCmd.Flags().StringVar(&clusterConf.ComputeNet, "compute-net", hostNetwork, "Network range for compute network")
 	setupCmd.Flags().StringVar(&clusterConf.MgmtNet, "mgmt-net", hostNetwork, "Network range for management network")
 	setupCmd.Flags().StringVar(&clusterConf.ServerIP, "server-ip", hostIP, "IP address nodes can reach this host on")
-
+	setupCmd.Flags().StringVar(&clusterConf.ServerHostname, "server-hostname", deploy.HostnameWithFallback(), "Name or FQDN that this host can be reached on")
 	setupCmd.Flags().StringVar(&imageCacheDirectory, "image-cache-directory", deploy.DefaultImageCacheDir(), "Directory to use for caching of downloaded images")
 	setupCmd.Flags().BoolVar(&force, "force", false, "Overwrite existing files which might break the cluster")
 	setupCmd.Flags().BoolVar(&localLauncher, "local-launcher", false, "Enable a local launcher on this node (for testing)")

--- a/ciao-deploy/deploy/setup.go
+++ b/ciao-deploy/deploy/setup.go
@@ -44,6 +44,7 @@ type ClusterConfiguration struct {
 	ServerIP          string
 	AuthCACertPath    string
 	AuthAdminCertPath string
+	ServerHostname    string
 }
 
 var ciaoConfigDir = "/etc/ciao"
@@ -306,7 +307,7 @@ func installController(ctx context.Context, controllerCertPath string, caCertPat
 }
 
 func setupEnvironment(conf *ClusterConfiguration) {
-	_ = os.Setenv("CIAO_CONTROLLER", HostnameWithFallback())
+	_ = os.Setenv("CIAO_CONTROLLER", conf.ServerHostname)
 	_ = os.Setenv("CIAO_ADMIN_CLIENT_CERT_FILE", conf.AuthAdminCertPath)
 }
 
@@ -314,7 +315,7 @@ func setupEnvironment(conf *ClusterConfiguration) {
 func OutputEnvironment(conf *ClusterConfiguration) {
 	fmt.Printf("Environment variables to access cluster:\n\n")
 
-	fmt.Printf("export CIAO_CONTROLLER=\"%s\"\n", HostnameWithFallback())
+	fmt.Printf("export CIAO_CONTROLLER=\"%s\"\n", conf.ServerHostname)
 	fmt.Printf("export CIAO_ADMIN_CLIENT_CERT_FILE=\"%s\"\n", conf.AuthAdminCertPath)
 }
 

--- a/ciao-deploy/deploy/setup.go
+++ b/ciao-deploy/deploy/setup.go
@@ -144,7 +144,7 @@ func createSchedulerCerts(ctx context.Context, force bool, serverIP string) (str
 	defer func() { _ = caCertFile.Close() }()
 	defer func() { _ = os.Remove(caCertFile.Name()) }()
 
-	hs := hostnameWithFallback()
+	hs := HostnameWithFallback()
 
 	hosts := []string{hs}
 	mgmtIPs := []string{serverIP}
@@ -306,7 +306,7 @@ func installController(ctx context.Context, controllerCertPath string, caCertPat
 }
 
 func setupEnvironment(conf *ClusterConfiguration) {
-	_ = os.Setenv("CIAO_CONTROLLER", hostnameWithFallback())
+	_ = os.Setenv("CIAO_CONTROLLER", HostnameWithFallback())
 	_ = os.Setenv("CIAO_ADMIN_CLIENT_CERT_FILE", conf.AuthAdminCertPath)
 }
 
@@ -314,7 +314,7 @@ func setupEnvironment(conf *ClusterConfiguration) {
 func OutputEnvironment(conf *ClusterConfiguration) {
 	fmt.Printf("Environment variables to access cluster:\n\n")
 
-	fmt.Printf("export CIAO_CONTROLLER=\"%s\"\n", hostnameWithFallback())
+	fmt.Printf("export CIAO_CONTROLLER=\"%s\"\n", HostnameWithFallback())
 	fmt.Printf("export CIAO_ADMIN_CLIENT_CERT_FILE=\"%s\"\n", conf.AuthAdminCertPath)
 }
 

--- a/ciao-deploy/deploy/utils.go
+++ b/ciao-deploy/deploy/utils.go
@@ -163,7 +163,8 @@ func InGoPath(path string) string {
 	return filepath.Join(gp, path)
 }
 
-func hostnameWithFallback() string {
+// HostnameWithFallback returns hostname with a fallback to localhost
+func HostnameWithFallback() string {
 	hs, err := os.Hostname()
 	if err != nil {
 		hs = "localhost"
@@ -173,7 +174,7 @@ func hostnameWithFallback() string {
 
 // CertName gives file name to use for downloaded certificate
 func CertName(role ssntp.Role) string {
-	return fmt.Sprintf("cert-%s-%s.pem", role.String(), hostnameWithFallback())
+	return fmt.Sprintf("cert-%s-%s.pem", role.String(), HostnameWithFallback())
 }
 
 // GenerateCert creates a certificate signed by the anchor certificate for a given role


### PR DESCRIPTION
When the HTTPS certificate uses a FQDN it is necessary to let the user of ciao-deploy specify the name the controller's certificate specifies so that the invocations of ciao-cli will work.

Fixes: #1459