### PR TITLE
Handle image upload failures

### DIFF
--- a/ciao-cli/image.go
+++ b/ciao-cli/image.go
@@ -132,7 +132,10 @@ func (cmd *imageAddCommand) run(args []string) error {
 		fatalf(err.Error())
 	}
 
-	uploadTenantImage(*tenantID, image.ID, cmd.file)
+	err = uploadTenantImage(*tenantID, image.ID, cmd.file)
+	if err != nil {
+		fatalf(err.Error())
+	}
 
 	url = buildImageURL("images/%s", image.ID)
 	resp, err = sendHTTPRequest("GET", url, nil, nil)
@@ -341,6 +344,10 @@ func uploadTenantImage(tenant, image, filename string) error {
 	url := buildImageURL("images/%s/file", image)
 	resp, err := sendHTTPRequestToken("PUT", url, nil, scopedToken, file, "octet-stream")
 	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("Unexpected HTTP response code (%d): %s", resp.StatusCode, resp.Status)
+	}
 
 	return err
 }

--- a/ciao-image/datastore/store.go
+++ b/ciao-image/datastore/store.go
@@ -164,7 +164,6 @@ func (s *ImageStore) DeleteImage(tenant, ID string) error {
 
 // UploadImage will read an image, save it and update the image cache.
 func (s *ImageStore) UploadImage(tenant, ID string, body io.Reader) error {
-
 	s.ImageMap.RLock()
 	img, err := s.metaDs.Get(tenant, ID)
 	s.ImageMap.RUnlock()
@@ -191,7 +190,6 @@ func (s *ImageStore) UploadImage(tenant, ID string, body io.Reader) error {
 		img.Size, err = s.rawDs.GetImageSize(ID)
 		if err != nil {
 			img.State = Killed
-			return err
 		}
 	}
 


### PR DESCRIPTION
When an image upload fails it should be reported to the user and the database correctly updated.

Fixes: #1469