### PR TITLE
ciao-controller: do not use a pointer for instance state lock

### DIFF
--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -256,7 +256,7 @@ func (c *controller) startWorkload(w types.WorkloadRequest) ([]*types.Instance, 
 				continue
 			}
 
-			newInstances = append(newInstances, &instance.Instance)
+			newInstances = append(newInstances, instance.Instance)
 			if w.TraceLabel == "" {
 				go c.client.StartWorkload(instance.newConfig.config)
 			} else {

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"sync"
 	"testing"
 	"time"
 
@@ -98,7 +97,6 @@ func addFakeCNCI(tenant *types.Tenant) (*types.Instance, error) {
 		IPAddress:  "192.168.0.1",
 		MACAddress: mac.String(),
 		Subnet:     "172.16.0.0/24",
-		StateLock:  &sync.RWMutex{},
 	}
 
 	return &CNCI, ctl.ds.AddInstance(&CNCI)

--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -42,7 +42,7 @@ type config struct {
 }
 
 type instance struct {
-	types.Instance
+	*types.Instance
 	newConfig config
 	ctl       *controller
 	startTime time.Time
@@ -95,7 +95,6 @@ func newInstance(ctl *controller, tenantID string, workload *types.Workload,
 		MACAddress:  config.mac,
 		CreateTime:  time.Now(),
 		Name:        name,
-		StateLock:   &sync.RWMutex{},
 		StateChange: sync.NewCond(&sync.Mutex{}),
 	}
 
@@ -106,7 +105,7 @@ func newInstance(ctl *controller, tenantID string, workload *types.Workload,
 	i := &instance{
 		ctl:       ctl,
 		newConfig: config,
-		Instance:  newInstance,
+		Instance:  &newInstance,
 	}
 
 	return i, nil
@@ -115,7 +114,7 @@ func newInstance(ctl *controller, tenantID string, workload *types.Workload,
 func (i *instance) Add() error {
 	ds := i.ctl.ds
 	var err error
-	err = ds.AddInstance(&i.Instance)
+	err = ds.AddInstance(i.Instance)
 	if err != nil {
 		return errors.Wrapf(err, "Error creating instance in datastore")
 	}

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -25,7 +25,6 @@ import (
 	"net"
 	"os"
 	"reflect"
-	"sync"
 	"testing"
 	"time"
 
@@ -163,7 +162,6 @@ func addTestTenant() (tenant *types.Tenant, err error) {
 		CNCI:       true,
 		IPAddress:  "192.168.0.1",
 		MACAddress: mac.String(),
-		StateLock:  &sync.RWMutex{},
 	}
 
 	err = ds.AddInstance(&CNCI)

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -112,22 +112,22 @@ type WorkloadRequest struct {
 
 // Instance contains information about an instance of a workload.
 type Instance struct {
-	ID          string        `json:"instance_id"`
-	TenantID    string        `json:"tenant_id"`
-	State       string        `json:"instance_state"`
-	WorkloadID  string        `json:"workload_id"`
-	NodeID      string        `json:"node_id"`
-	MACAddress  string        `json:"mac_address"`
-	VnicUUID    string        `json:"vnic_uuid"`
-	Subnet      string        `json:"subnet"`
-	IPAddress   string        `json:"ip_address"`
-	SSHIP       string        `json:"ssh_ip"`
-	SSHPort     int           `json:"ssh_port"`
-	CNCI        bool          `json:"-"`
-	CreateTime  time.Time     `json:"-"`
-	Name        string        `json:"name"`
-	StateLock   *sync.RWMutex `json:"-"`
-	StateChange *sync.Cond    `json:"-"`
+	ID          string       `json:"instance_id"`
+	TenantID    string       `json:"tenant_id"`
+	State       string       `json:"instance_state"`
+	WorkloadID  string       `json:"workload_id"`
+	NodeID      string       `json:"node_id"`
+	MACAddress  string       `json:"mac_address"`
+	VnicUUID    string       `json:"vnic_uuid"`
+	Subnet      string       `json:"subnet"`
+	IPAddress   string       `json:"ip_address"`
+	SSHIP       string       `json:"ssh_ip"`
+	SSHPort     int          `json:"ssh_port"`
+	CNCI        bool         `json:"-"`
+	CreateTime  time.Time    `json:"-"`
+	Name        string       `json:"name"`
+	StateLock   sync.RWMutex `json:"-"`
+	StateChange *sync.Cond   `json:"-"`
 }
 
 // SortedInstancesByID implements sort.Interface for Instance by ID string


### PR DESCRIPTION
Change the instance StateLock to be a struct rather than a pointer.
This way it is initialized at Instance creation.

Fixes: #1467

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>