### PR TITLE
Disable live detach in controller

### DIFF
--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -644,7 +644,7 @@ func addTestBlockDevice(t *testing.T, tenantID string) types.BlockData {
 }
 
 // Note: caller should close ssntp client
-func doAttachVolumeCommand(t *testing.T, fail bool) (client *testutil.SsntpTestClient, tenant string, volume string) {
+func doAttachVolumeCommand(t *testing.T, fail bool) (client *testutil.SsntpTestClient, tenant string, volume string, instanceID string) {
 	var reason payloads.StartFailureReason
 
 	client, instances := testStartWorkload(t, 1, false, reason)
@@ -721,22 +721,22 @@ func doAttachVolumeCommand(t *testing.T, fail bool) (client *testutil.SsntpTestC
 		}
 	}
 
-	return client, tenantID, data.ID
+	return client, tenantID, data.ID, instances[0].ID
 }
 
 func TestAttachVolumeCommand(t *testing.T) {
-	client, _, _ := doAttachVolumeCommand(t, false)
+	client, _, _, _ := doAttachVolumeCommand(t, false)
 	client.Ssntp.Close()
 }
 
 func TestAttachVolumeFailure(t *testing.T) {
-	client, _, _ := doAttachVolumeCommand(t, true)
+	client, _, _, _ := doAttachVolumeCommand(t, true)
 	client.Ssntp.Close()
 }
 
 func doDetachVolumeCommand(t *testing.T, fail bool) {
 	// attach volume should succeed for this test
-	client, tenantID, volume := doAttachVolumeCommand(t, false)
+	client, tenantID, volume, _ := doAttachVolumeCommand(t, false)
 	defer client.Ssntp.Close()
 
 	sendStatsCmd(client, t)

--- a/ciao-controller/openstack_volume.go
+++ b/ciao-controller/openstack_volume.go
@@ -280,19 +280,21 @@ func (c *controller) DetachVolume(tenant string, volume string, attachment strin
 			continue
 		}
 
+		i.StateLock.RLock()
+		state := i.State
+		i.StateLock.RUnlock()
+
+		if state != payloads.Exited {
+			retval = errors.New("Can only detach from exited instances")
+			continue
+		}
+
 		// update volume state to detaching
-		info.State = types.Detaching
+		info.State = types.Available
 
 		err = c.ds.UpdateBlockDevice(info)
 		if err != nil {
 			return err
-		}
-
-		// send command to attach volume.
-		err = c.client.detachVolume(a.BlockID, a.InstanceID, i.NodeID)
-		if err != nil {
-			retval = err
-			glog.Errorf("Can't detach volume %s from instance %s\n", a.BlockID, a.InstanceID)
 		}
 	}
 

--- a/ciao-controller/openstack_volume.go
+++ b/ciao-controller/openstack_volume.go
@@ -267,14 +267,6 @@ func (c *controller) DetachVolume(tenant string, volume string, attachment strin
 		}
 	}
 
-	// update volume state to detaching
-	info.State = types.Detaching
-
-	err = c.ds.UpdateBlockDevice(info)
-	if err != nil {
-		return err
-	}
-
 	var retval error
 
 	// detach everything for this volume
@@ -286,6 +278,14 @@ func (c *controller) DetachVolume(tenant string, volume string, attachment strin
 			// keep going
 			retval = err
 			continue
+		}
+
+		// update volume state to detaching
+		info.State = types.Detaching
+
+		err = c.ds.UpdateBlockDevice(info)
+		if err != nil {
+			return err
 		}
 
 		// send command to attach volume.


### PR DESCRIPTION
Reject requests to detach volumes from instances that are not exited as live detach is flaky due to relying on guest OS support. Update the BAT tests to stop the instances prior to trying to detach.

Fixes: #1315