### PR TITLE
ciao-deploy: make ciao-launcher --hard-reset work

### DIFF
--- a/ciao-deploy/deploy/nodes.go
+++ b/ciao-deploy/deploy/nodes.go
@@ -232,10 +232,10 @@ func teardownNode(ctx context.Context, hostname string, sshUser string) error {
 	// Need extra timeout here due to #343
 	fmt.Printf("%s: Performing ciao-launcher hard reset\n", hostname)
 	timeoutContext, cancelFunc := context.WithTimeout(ctx, time.Second*60)
-	err = SSHRunCommand(timeoutContext, sshUser, hostname, "sudo ciao-launcher --hard-reset")
+	out, err := SSHRunCommandOutput(timeoutContext, sshUser, hostname, "sudo ciao-launcher --hard-reset")
 	cancelFunc()
 	if timeoutContext.Err() != context.DeadlineExceeded && err != nil {
-		return errors.Wrap(err, "Error doing hard-reset on ciao-launcher")
+		return errors.Wrap(err, fmt.Sprintf("Error doing hard-reset on ciao-launcher: %s", string(out)))
 	}
 
 	fmt.Printf("%s: Removing %s binary\n", hostname, tool)

--- a/ciao-deploy/deploy/nodes.go
+++ b/ciao-deploy/deploy/nodes.go
@@ -230,16 +230,16 @@ func teardownNode(ctx context.Context, hostname string, sshUser string) error {
 	}
 
 	// Need extra timeout here due to #343
+	systemToolPath := path.Join("/usr/local/bin/", tool)
 	fmt.Printf("%s: Performing ciao-launcher hard reset\n", hostname)
 	timeoutContext, cancelFunc := context.WithTimeout(ctx, time.Second*60)
-	out, err := SSHRunCommandOutput(timeoutContext, sshUser, hostname, "sudo ciao-launcher --hard-reset")
+	out, err := SSHRunCommandOutput(timeoutContext, sshUser, hostname, fmt.Sprintf("sudo %s --hard-reset", systemToolPath))
 	cancelFunc()
 	if timeoutContext.Err() != context.DeadlineExceeded && err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Error doing hard-reset on ciao-launcher: %s", string(out)))
 	}
 
 	fmt.Printf("%s: Removing %s binary\n", hostname, tool)
-	systemToolPath := path.Join("/usr/local/bin/", tool)
 	err = SSHRunCommand(ctx, sshUser, hostname, fmt.Sprintf("sudo rm %s", systemToolPath))
 	if err != nil {
 		return errors.Wrap(err, "Error removing tool binary")

--- a/ciao-deploy/deploy/nodes.go
+++ b/ciao-deploy/deploy/nodes.go
@@ -224,9 +224,9 @@ func teardownNode(ctx context.Context, hostname string, sshUser string) error {
 	networkAgentCertPath := path.Join(ciaoPKIDir, fmt.Sprintf("cert-%s-%s.pem", networkAgentRole.String(), hostname))
 	_ = SSHRunCommand(ctx, sshUser, hostname, fmt.Sprintf("sudo rm %s", networkAgentCertPath))
 
-	err = SSHRunCommand(ctx, sshUser, hostname, fmt.Sprintf("sudo rmdir %s", ciaoPKIDir))
+	output, err := SSHRunCommandOutput(ctx, sshUser, hostname, fmt.Sprintf("sudo rmdir %s", ciaoPKIDir))
 	if err != nil {
-		return errors.Wrap(err, "Error removing ciao PKI directory")
+		return errors.Wrap(err, fmt.Sprintf("Error removing ciao PKI directory: %s", string(output)))
 	}
 
 	// Need extra timeout here due to #343

--- a/ciao-deploy/deploy/utils.go
+++ b/ciao-deploy/deploy/utils.go
@@ -286,6 +286,25 @@ func SSHRunCommand(ctx context.Context, user string, host string, command string
 	return session.Run(command)
 }
 
+// SSHRunCommandOutput is a convenience function to run a command on a given host.
+// It will return the combined stdout and stderr output to the caller.
+// This assumes the key is already in the keyring for the provided user.
+func SSHRunCommandOutput(ctx context.Context, user string, host string, command string) ([]byte, error) {
+	client, err := sshClient(ctx, user, host)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error creating client")
+	}
+	defer func() { _ = client.Close() }()
+
+	session, err := client.NewSession()
+	if err != nil {
+		return nil, errors.Wrap(err, "Error creating session")
+	}
+	defer func() { _ = session.Close() }()
+
+	return session.CombinedOutput(command)
+}
+
 // SSHCreateFile creates a file on a remote machine
 func SSHCreateFile(ctx context.Context, user string, host string, dest string, f io.Reader) error {
 	client, err := sshClient(ctx, user, host)


### PR DESCRIPTION
This PR has 3 changes:
* output the combined stdout/stderr of ciao-launcher --hard-reset when it fails in addition to the exit code.
* output the combined stdout/stderr of rmdir /etc/pki/ciao - if this fails it prevents launcher from being reset.
* use an absolute path for ciao-launcher, as "sudo ciao-launcher --hard-reset" assumes /usr/local/bin/ciao-launcher is in your path (and it isn't always)

