### PR TITLE
ciao-deploy: use absolute path for launcher when resetting

### DIFF
--- a/ciao-deploy/deploy/nodes.go
+++ b/ciao-deploy/deploy/nodes.go
@@ -230,16 +230,16 @@ func teardownNode(ctx context.Context, hostname string, sshUser string) error {
 	}
 
 	// Need extra timeout here due to #343
+	systemToolPath := path.Join("/usr/local/bin/", tool)
 	fmt.Printf("%s: Performing ciao-launcher hard reset\n", hostname)
 	timeoutContext, cancelFunc := context.WithTimeout(ctx, time.Second*60)
-	err = SSHRunCommand(timeoutContext, sshUser, hostname, "sudo ciao-launcher --hard-reset")
+	err = SSHRunCommand(timeoutContext, sshUser, hostname, fmt.Sprintf("sudo %s --hard-reset", systemToolPath))
 	cancelFunc()
 	if timeoutContext.Err() != context.DeadlineExceeded && err != nil {
 		return errors.Wrap(err, "Error doing hard-reset on ciao-launcher")
 	}
 
 	fmt.Printf("%s: Removing %s binary\n", hostname, tool)
-	systemToolPath := path.Join("/usr/local/bin/", tool)
 	err = SSHRunCommand(ctx, sshUser, hostname, fmt.Sprintf("sudo rm %s", systemToolPath))
 	if err != nil {
 		return errors.Wrap(err, "Error removing tool binary")


### PR DESCRIPTION
Use the absolute path for launcher when resetting because /usr/local/bin
isn't always in the default system PATH.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>