### PR TITLE
report Node Hostname information with node list/show

### DIFF
--- a/ciao-cli/node.go
+++ b/ciao-cli/node.go
@@ -120,6 +120,7 @@ func (cmd *nodeListCommand) run(args []string) error {
 }
 
 func dumpNode(node *types.CiaoNode) {
+	fmt.Printf("\tHostname: %s\n", node.Hostname)
 	fmt.Printf("\tUUID: %s\n", node.ID)
 	fmt.Printf("\tStatus: %s\n", node.Status)
 	fmt.Printf("\tLoad: %d\n", node.Load)

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -1292,6 +1292,7 @@ func (ds *Datastore) addNodeStat(stat payloads.Stat) error {
 
 	cnStat := types.CiaoNode{
 		ID:            stat.NodeUUID,
+		Hostname:      n.Hostname,
 		Status:        stat.Status,
 		Load:          stat.Load,
 		MemTotal:      stat.MemTotalMB,

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -299,6 +299,7 @@ type StorageAttachment struct {
 // node.
 type CiaoNode struct {
 	ID                    string    `json:"id"`
+	Hostname              string    `json:"hostname"`
 	Timestamp             time.Time `json:"updated"`
 	Status                string    `json:"status"`
 	MemTotal              int       `json:"ram_total"`


### PR DESCRIPTION
Modify types.CiaoNode to contain a Hostname value. Populate
this value when stats are received from a node. Modify ciao-cli
to dump the Hostname value.

Fixes: #1462 

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>

