### PR TITLE
Report NodeID in launcher error payloads

### DIFF
--- a/ciao-launcher/attachvolume_error.go
+++ b/ciao-launcher/attachvolume_error.go
@@ -32,7 +32,7 @@ func (ave *attachVolumeError) send(conn serverConn, instance, volume string) {
 		return
 	}
 
-	payload, err := generateAttachVolumeError(instance, volume, ave)
+	payload, err := generateAttachVolumeError(conn.UUID(), instance, volume, ave)
 	if err != nil {
 		glog.Errorf("Unable to generate payload for attach_volume_failure: %v", err)
 		return

--- a/ciao-launcher/delete_error.go
+++ b/ciao-launcher/delete_error.go
@@ -32,7 +32,7 @@ func (de *deleteError) send(conn serverConn, instance string) {
 		return
 	}
 
-	payload, err := generateDeleteError(instance, de)
+	payload, err := generateDeleteError(conn.UUID(), instance, de)
 	if err != nil {
 		glog.Errorf("Unable to generate payload for delete_failure: %v", err)
 		return

--- a/ciao-launcher/detachvolume_error.go
+++ b/ciao-launcher/detachvolume_error.go
@@ -32,7 +32,7 @@ func (dve *detachVolumeError) send(conn serverConn, instance, volume string) {
 		return
 	}
 
-	payload, err := generateDetachVolumeError(instance, volume, dve)
+	payload, err := generateDetachVolumeError(conn.UUID(), instance, volume, dve)
 	if err != nil {
 		glog.Errorf("Unable to generate payload for detach_volume_failure: %v", err)
 		return

--- a/ciao-launcher/payload.go
+++ b/ciao-launcher/payload.go
@@ -27,7 +27,7 @@ import (
 	"github.com/ciao-project/ciao/networking/libsnnet"
 	"github.com/ciao-project/ciao/payloads"
 	"github.com/golang/glog"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 type payloadError struct {
@@ -195,8 +195,9 @@ func parseStartPayload(data []byte) (*vmConfig, *payloadError) {
 	}, nil
 }
 
-func generateStartError(instance string, startErr *startError) (out []byte, err error) {
+func generateStartError(node, instance string, startErr *startError) (out []byte, err error) {
 	sf := &payloads.ErrorStartFailure{
+		NodeUUID:     node,
 		InstanceUUID: instance,
 		Reason:       startErr.code,
 		Restart:      startErr.restart,
@@ -204,16 +205,18 @@ func generateStartError(instance string, startErr *startError) (out []byte, err 
 	return yaml.Marshal(sf)
 }
 
-func generateDeleteError(instance string, deleteErr *deleteError) (out []byte, err error) {
+func generateDeleteError(node, instance string, deleteErr *deleteError) (out []byte, err error) {
 	df := &payloads.ErrorDeleteFailure{
+		NodeUUID:     node,
 		InstanceUUID: instance,
 		Reason:       deleteErr.code,
 	}
 	return yaml.Marshal(df)
 }
 
-func generateAttachVolumeError(instance, volume string, ave *attachVolumeError) (out []byte, err error) {
+func generateAttachVolumeError(node, instance, volume string, ave *attachVolumeError) (out []byte, err error) {
 	avf := &payloads.ErrorAttachVolumeFailure{
+		NodeUUID:     node,
 		InstanceUUID: instance,
 		VolumeUUID:   volume,
 		Reason:       ave.code,
@@ -221,8 +224,9 @@ func generateAttachVolumeError(instance, volume string, ave *attachVolumeError) 
 	return yaml.Marshal(avf)
 }
 
-func generateDetachVolumeError(instance, volume string, dve *detachVolumeError) (out []byte, err error) {
+func generateDetachVolumeError(node, instance, volume string, dve *detachVolumeError) (out []byte, err error) {
 	dvf := &payloads.ErrorDetachVolumeFailure{
+		NodeUUID:     node,
 		InstanceUUID: instance,
 		VolumeUUID:   volume,
 		Reason:       dve.code,

--- a/ciao-launcher/start_error.go
+++ b/ciao-launcher/start_error.go
@@ -33,7 +33,7 @@ func (se *startError) send(conn serverConn, instance string) {
 		return
 	}
 
-	payload, err := generateStartError(instance, se)
+	payload, err := generateStartError(conn.UUID(), instance, se)
 	if err != nil {
 		glog.Errorf("Unable to generate payload for start_failure: %v", err)
 		return

--- a/payloads/attachvolumefailure.go
+++ b/payloads/attachvolumefailure.go
@@ -60,6 +60,9 @@ const (
 // ErrorAttachVolumeFailure represents the unmarshalled version of the contents of a
 // SSNTP ERROR frame whose type is set to ssntp.AttachVolumeFailure.
 type ErrorAttachVolumeFailure struct {
+	// NodeUUID is the UUID of the node that generated this error.
+	NodeUUID string `yaml:"node_uuid"`
+
 	// InstanceUUID is the UUID of the instance to which a volume could not be
 	// attached.
 	InstanceUUID string `yaml:"instance_uuid"`

--- a/payloads/attachvolumefailure_test.go
+++ b/payloads/attachvolumefailure_test.go
@@ -21,7 +21,7 @@ import (
 
 	. "github.com/ciao-project/ciao/payloads"
 	"github.com/ciao-project/ciao/testutil"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func TestAttachVolumeFailureUnmarshal(t *testing.T) {
@@ -31,12 +31,16 @@ func TestAttachVolumeFailureUnmarshal(t *testing.T) {
 		t.Error(err)
 	}
 
+	if error.NodeUUID != testutil.AgentUUID {
+		t.Error("Wrong Node UUID field")
+	}
+
 	if error.InstanceUUID != testutil.InstanceUUID {
-		t.Error("Wrong UUID field")
+		t.Error("Wrong Instance UUID field")
 	}
 
 	if error.VolumeUUID != testutil.VolumeUUID {
-		t.Error("Wrong UUID field")
+		t.Error("Wrong Volume UUID field")
 	}
 
 	if error.Reason != AttachVolumeAttachFailure {
@@ -46,6 +50,7 @@ func TestAttachVolumeFailureUnmarshal(t *testing.T) {
 
 func TestAttachVolumeFailureMarshal(t *testing.T) {
 	error := ErrorAttachVolumeFailure{
+		NodeUUID:     testutil.AgentUUID,
 		InstanceUUID: testutil.InstanceUUID,
 		VolumeUUID:   testutil.VolumeUUID,
 		Reason:       AttachVolumeAttachFailure,

--- a/payloads/deletefailure.go
+++ b/payloads/deletefailure.go
@@ -39,6 +39,9 @@ const (
 // ErrorDeleteFailure represents the unmarshalled version of the contents of a
 // SSNTP ERROR frame whose type is set to ssntp.DeleteFailure.
 type ErrorDeleteFailure struct {
+	// NodeUUID is the UUID of the node that generated this error.
+	NodeUUID string `yaml:"node_uuid"`
+
 	// InstanceUUID is the UUID of the instance that could not be deleted.
 	InstanceUUID string `yaml:"instance_uuid"`
 

--- a/payloads/deletefailure_test.go
+++ b/payloads/deletefailure_test.go
@@ -21,7 +21,7 @@ import (
 
 	. "github.com/ciao-project/ciao/payloads"
 	"github.com/ciao-project/ciao/testutil"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func TestDeleteFailureUnmarshal(t *testing.T) {
@@ -31,8 +31,12 @@ func TestDeleteFailureUnmarshal(t *testing.T) {
 		t.Error(err)
 	}
 
+	if error.NodeUUID != testutil.AgentUUID {
+		t.Error("Wrong Node UUID field")
+	}
+
 	if error.InstanceUUID != testutil.InstanceUUID {
-		t.Error("Wrong UUID field")
+		t.Error("Wrong Instance UUID field")
 	}
 
 	if error.Reason != DeleteNoInstance {
@@ -42,6 +46,7 @@ func TestDeleteFailureUnmarshal(t *testing.T) {
 
 func TestDeleteFailureMarshal(t *testing.T) {
 	error := ErrorDeleteFailure{
+		NodeUUID:     testutil.AgentUUID,
 		InstanceUUID: testutil.InstanceUUID,
 		Reason:       DeleteNoInstance,
 	}

--- a/payloads/detachvolumefailure.go
+++ b/payloads/detachvolumefailure.go
@@ -60,6 +60,9 @@ const (
 // ErrorDetachVolumeFailure represents the unmarshalled version of the contents of a
 // SSNTP ERROR frame whose type is set to ssntp.DetachVolumeFailure.
 type ErrorDetachVolumeFailure struct {
+	// NodeUUID is the UUID of the node that generated this error.
+	NodeUUID string `yaml:"node_uuid"`
+
 	// InstanceUUID is the UUID of the instance from which a volume could not be
 	// detached.
 	InstanceUUID string `yaml:"instance_uuid"`

--- a/payloads/detachvolumefailure_test.go
+++ b/payloads/detachvolumefailure_test.go
@@ -21,7 +21,7 @@ import (
 
 	. "github.com/ciao-project/ciao/payloads"
 	"github.com/ciao-project/ciao/testutil"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func TestDetachVolumeFailureUnmarshal(t *testing.T) {
@@ -31,12 +31,16 @@ func TestDetachVolumeFailureUnmarshal(t *testing.T) {
 		t.Error(err)
 	}
 
+	if error.NodeUUID != testutil.AgentUUID {
+		t.Error("Wrong Node UUID field")
+	}
+
 	if error.InstanceUUID != testutil.InstanceUUID {
-		t.Error("Wrong UUID field")
+		t.Error("Wrong Instance UUID field")
 	}
 
 	if error.VolumeUUID != testutil.VolumeUUID {
-		t.Error("Wrong UUID field")
+		t.Error("Wrong Volume UUID field")
 	}
 
 	if error.Reason != DetachVolumeDetachFailure {
@@ -46,6 +50,7 @@ func TestDetachVolumeFailureUnmarshal(t *testing.T) {
 
 func TestDetachVolumeFailureMarshal(t *testing.T) {
 	error := ErrorDetachVolumeFailure{
+		NodeUUID:     testutil.AgentUUID,
 		InstanceUUID: testutil.InstanceUUID,
 		VolumeUUID:   testutil.VolumeUUID,
 		Reason:       DetachVolumeDetachFailure,

--- a/payloads/startfailure.go
+++ b/payloads/startfailure.go
@@ -87,6 +87,9 @@ const (
 // ErrorStartFailure represents the unmarshalled version of the contents of a
 // SSNTP ERROR frame whose type is set to ssntp.StartFailure.
 type ErrorStartFailure struct {
+	// NodeUUID is the UUID of the node that generated this error.
+	NodeUUID string `yaml:"node_uuid"`
+
 	// InstanceUUID is the UUID of the instance that could not be started.
 	InstanceUUID string `yaml:"instance_uuid"`
 

--- a/payloads/startfailure_test.go
+++ b/payloads/startfailure_test.go
@@ -21,7 +21,7 @@ import (
 
 	. "github.com/ciao-project/ciao/payloads"
 	"github.com/ciao-project/ciao/testutil"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func TestStartFailureUnmarshal(t *testing.T) {
@@ -31,8 +31,12 @@ func TestStartFailureUnmarshal(t *testing.T) {
 		t.Error(err)
 	}
 
+	if error.NodeUUID != testutil.AgentUUID {
+		t.Error("Wrong Node UUID field")
+	}
+
 	if error.InstanceUUID != testutil.InstanceUUID {
-		t.Error("Wrong UUID field")
+		t.Error("Wrong Instance UUID field")
 	}
 
 	if error.Reason != FullCloud {
@@ -42,6 +46,7 @@ func TestStartFailureUnmarshal(t *testing.T) {
 
 func TestStartFailureMarshal(t *testing.T) {
 	error := ErrorStartFailure{
+		NodeUUID:     testutil.AgentUUID,
 		InstanceUUID: testutil.InstanceUUID,
 		Reason:       FullCloud,
 	}

--- a/testutil/payloads.go
+++ b/testutil/payloads.go
@@ -205,7 +205,8 @@ const PartialStartYaml = `start:
 `
 
 // StartFailureYaml is a sample workload StartFailure ssntp.Error payload for test cases
-const StartFailureYaml = `instance_uuid: ` + InstanceUUID + `
+const StartFailureYaml = `node_uuid: ` + AgentUUID + `
+instance_uuid: ` + InstanceUUID + `
 reason: full_cloud
 restart: false
 `
@@ -392,7 +393,8 @@ const ConfigureYaml = `configure:
 `
 
 // DeleteFailureYaml is a sample workload DeleteFailure ssntp.Error payload for test cases
-const DeleteFailureYaml = `instance_uuid: ` + InstanceUUID + `
+const DeleteFailureYaml = `node_uuid: ` + AgentUUID + `
+instance_uuid: ` + InstanceUUID + `
 reason: no_instance
 `
 
@@ -604,13 +606,15 @@ const BadDetachVolumeYaml = `detach_volume:
 `
 
 // AttachVolumeFailureYaml is a sample AttachVolumeFailure ssntp.Error payload for test cases
-const AttachVolumeFailureYaml = `instance_uuid: ` + InstanceUUID + `
+const AttachVolumeFailureYaml = `node_uuid: ` + AgentUUID + `
+instance_uuid: ` + InstanceUUID + `
 volume_uuid: ` + VolumeUUID + `
 reason: attach_failure
 `
 
 // DetachVolumeFailureYaml is a sample DetachVolumeFailure ssntp.Error payload for test cases
-const DetachVolumeFailureYaml = `instance_uuid: ` + InstanceUUID + `
+const DetachVolumeFailureYaml = `node_uuid: ` + AgentUUID + `
+instance_uuid: ` + InstanceUUID + `
 volume_uuid: ` + VolumeUUID + `
 reason: detach_failure
 `


### PR DESCRIPTION
This PR modifies the error payloads sent by launcher and launcher itself, so that these errors contain the node id of the node that generated the error.