### PR TITLE
Add failure stats to ciao nodes

### DIFF
--- a/ciao-cli/node.go
+++ b/ciao-cli/node.go
@@ -130,6 +130,11 @@ func dumpNode(node *types.CiaoNode) {
 	fmt.Printf("\t\tRunning Instances: %d\n", node.TotalRunningInstances)
 	fmt.Printf("\t\tPending Instances: %d\n", node.TotalPendingInstances)
 	fmt.Printf("\t\tPaused Instances: %d\n", node.TotalPausedInstances)
+	fmt.Printf("\t\tTotal Failures: %d\n", node.TotalFailures)
+	fmt.Printf("\t\tTotal Start Failures: %d\n", node.StartFailures)
+	fmt.Printf("\t\tTotal Delete Failures: %d\n", node.DeleteFailures)
+	fmt.Printf("\t\tTotal Attach Failures: %d\n", node.AttachVolumeFailures)
+	fmt.Printf("\t\tTotal Detach Failures: %d\n", node.DetachVolumeFailures)
 }
 
 func dumpNodes(headerText string, url string, t *template.Template) {

--- a/ciao-controller/client.go
+++ b/ciao-controller/client.go
@@ -366,7 +366,7 @@ func (client *ssntpClient) startFailure(payload []byte) {
 	cnci := i.CNCI
 	tenantID := i.TenantID
 
-	err = client.ctl.ds.StartFailure(failure.InstanceUUID, failure.Reason, failure.Restart)
+	err = client.ctl.ds.StartFailure(failure.InstanceUUID, failure.Reason, failure.Restart, failure.NodeUUID)
 	if err != nil {
 		glog.Warningf("Error adding StartFailure to datastore: %v", err)
 	}
@@ -451,7 +451,7 @@ func (client *ssntpClient) assignError(payload []byte) {
 	client.ctl.qs.Release(failure.TenantUUID, payloads.RequestedResource{Type: payloads.ExternalIP, Value: 1})
 
 	msg := fmt.Sprintf("Failed to map %s to %s: %s", failure.PublicIP, failure.InstanceUUID, failure.Reason.String())
-	client.ctl.ds.LogEvent(failure.TenantUUID, msg)
+	client.ctl.ds.LogError(failure.TenantUUID, msg)
 }
 
 func (client *ssntpClient) unassignError(payload []byte) {
@@ -464,7 +464,7 @@ func (client *ssntpClient) unassignError(payload []byte) {
 
 	// we can't unmap the IP - all we can do is log.
 	msg := fmt.Sprintf("Failed to unmap %s from %s: %s", failure.PublicIP, failure.InstanceUUID, failure.Reason.String())
-	client.ctl.ds.LogEvent(failure.TenantUUID, msg)
+	client.ctl.ds.LogError(failure.TenantUUID, msg)
 }
 
 func (client *ssntpClient) ErrorNotify(err ssntp.Error, frame *ssntp.Frame) {

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -777,7 +777,12 @@ func TestGetBatchFrameSummary(t *testing.T) {
 }
 
 func TestGetEventLog(t *testing.T) {
-	err := ds.db.logEvent("test-tenantID", "info", "this is a test")
+	e := types.LogEntry{
+		TenantID:  "test-tenantID",
+		EventType: "info",
+		Message:   "this is a test",
+	}
+	err := ds.db.logEvent(e)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -789,7 +794,12 @@ func TestGetEventLog(t *testing.T) {
 }
 
 func TestLogEvent(t *testing.T) {
-	err := ds.db.logEvent("test-tenantID", "info", "this is a test")
+	e := types.LogEntry{
+		TenantID:  "test-tenantID",
+		EventType: "info",
+		Message:   "this is a test",
+	}
+	err := ds.db.logEvent(e)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1181,7 +1191,7 @@ func TestStartFailureFullCloud(t *testing.T) {
 
 	reason := payloads.FullCloud
 
-	err = ds.StartFailure(instance.ID, reason, false)
+	err = ds.StartFailure(instance.ID, reason, false, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ciao-controller/internal/datastore/memorydb.go
+++ b/ciao-controller/internal/datastore/memorydb.go
@@ -63,13 +63,7 @@ func (db *MemoryDB) disconnect() {
 
 }
 
-func (db *MemoryDB) logEvent(tenantID string, eventType string, message string) error {
-	entry := types.LogEntry{
-		TenantID:  tenantID,
-		EventType: eventType,
-		Message:   message,
-	}
-
+func (db *MemoryDB) logEvent(entry types.LogEntry) error {
 	db.logEntries = append(db.logEntries, &entry)
 
 	return nil

--- a/ciao-controller/internal/datastore/sqlite3db_test.go
+++ b/ciao-controller/internal/datastore/sqlite3db_test.go
@@ -845,7 +845,13 @@ func TestSQLiteDBEventLog(t *testing.T) {
 
 	tn := createTestTenant(db, t)
 
-	err = db.logEvent(tn.ID, string(userError), "test message 1")
+	e := types.LogEntry{
+		TenantID:  tn.ID,
+		EventType: string(userError),
+		Message:   "test message 1",
+		NodeID:    "validNodeID",
+	}
+	err = db.logEvent(e)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -858,7 +864,8 @@ func TestSQLiteDBEventLog(t *testing.T) {
 		t.Fatal("Expected 1 log message")
 	}
 
-	err = db.logEvent(tn.ID, string(userError), "test message 2")
+	e.Message = "test message 2"
+	err = db.logEvent(e)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -180,6 +180,7 @@ type TenantRequest struct {
 type LogEntry struct {
 	Timestamp time.Time `json:"time_stamp"`
 	TenantID  string    `json:"tenant_id"`
+	NodeID    string    `json:"node_id"`
 	EventType string    `json:"type"`
 	Message   string    `json:"message"`
 }
@@ -203,6 +204,7 @@ type NodeSummary struct {
 	TotalRunningInstances int    `json:"total_running_instances"`
 	TotalPendingInstances int    `json:"total_pending_instances"`
 	TotalPausedInstances  int    `json:"total_paused_instances"`
+	TotalFailures         int    `json:"total_failures"`
 }
 
 // TenantCNCI contains information about the CNCI instance for a tenant.
@@ -245,10 +247,15 @@ type BatchFrameSummary struct {
 
 // Node contains information about a physical node in the cluster.
 type Node struct {
-	ID       string     `json:"node_id"`
-	IPAddr   string     `json:"ip_address"`
-	Hostname string     `json:"hostname"`
-	NodeRole ssntp.Role `json:"role"`
+	ID                   string     `json:"node_id"`
+	IPAddr               string     `json:"ip_address"`
+	Hostname             string     `json:"hostname"`
+	TotalFailures        int        `json:"total_failures"`
+	StartFailures        int        `json:"start_failures"`
+	AttachVolumeFailures int        `json:"attach_failures"`
+	DeleteFailures       int        `json:"delete_failures"`
+	DetachVolumeFailures int        `json:"detach_failures"`
+	NodeRole             ssntp.Role `json:"role"`
 }
 
 // BlockState represents the state of the block device in the controller
@@ -312,6 +319,11 @@ type CiaoNode struct {
 	TotalRunningInstances int       `json:"total_running_instances"`
 	TotalPendingInstances int       `json:"total_pending_instances"`
 	TotalPausedInstances  int       `json:"total_paused_instances"`
+	TotalFailures         int       `json:"total_failures"`
+	StartFailures         int       `json:"start_failures"`
+	AttachVolumeFailures  int       `json:"attach_failures"`
+	DeleteFailures        int       `json:"delete_failures"`
+	DetachVolumeFailures  int       `json:"detach_failures"`
 }
 
 // NodeStatusType contains the valid values of a node's status


### PR DESCRIPTION
If we have node information for a failure, store and increment
stats per node and report via CiaoNode. Note that these stats
are not persistent - they will be cleared when the node is
removed or when the controller is restarted.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>