### PR TITLE
Restrict subnet-bits value to a range between 12-30

### DIFF
--- a/_release/bat/tenant_bat/tenant_bat_test.go
+++ b/_release/bat/tenant_bat/tenant_bat_test.go
@@ -54,7 +54,7 @@ func TestCreateTenant(t *testing.T) {
 
 	config := bat.TenantConfig{
 		Name:       "CreateTenantTest",
-		SubnetBits: 4,
+		SubnetBits: 20,
 	}
 
 	tenant, err := bat.CreateTenant(ctx, config)

--- a/bat/tenant.go
+++ b/bat/tenant.go
@@ -61,7 +61,7 @@ func GetAllTenants(ctx context.Context) (TenantsListResponse, error) {
 func CreateTenant(ctx context.Context, config TenantConfig) (TenantSummary, error) {
 	var summary TenantSummary
 
-	args := []string{"tenant", "create", "-tenant", uuid.Generate().String(), "-name", config.Name, "-subnet-bits", strconv.Itoa(config.SubnetBits), "-f", "{{tojson .}}"}
+	args := []string{"tenant", "create", "-tenant", uuid.Generate().String(), "-name", config.Name, "-cidr-prefix-size", strconv.Itoa(config.SubnetBits), "-f", "{{tojson .}}"}
 	err := RunCIAOCLIAsAdminJS(ctx, "", args, &summary)
 
 	return summary, err
@@ -77,7 +77,7 @@ func UpdateTenant(ctx context.Context, ID string, config TenantConfig) error {
 	}
 
 	if config.SubnetBits != 0 {
-		bits := []string{"-subnet-bits", strconv.Itoa(config.SubnetBits)}
+		bits := []string{"-cidr-prefix-size", strconv.Itoa(config.SubnetBits)}
 		args = append(args, bits...)
 	}
 

--- a/ciao-controller/tenants.go
+++ b/ciao-controller/tenants.go
@@ -81,12 +81,12 @@ func (c *controller) CreateTenant(tenantID string, config types.TenantConfig) (t
 		return types.TenantSummary{}, err
 	}
 
-	// SubnetBits must be between 4 and 30
+	// SubnetBits must be between 12 and 30
 	if config.SubnetBits == 0 {
 		config.SubnetBits = 24
 	} else {
-		if config.SubnetBits < 4 || config.SubnetBits > 30 {
-			return types.TenantSummary{}, errors.New("subnet bits must be between 4 and 30")
+		if config.SubnetBits < 12 || config.SubnetBits > 30 {
+			return types.TenantSummary{}, errors.New("subnet bits must be between 12 and 30")
 		}
 	}
 


### PR DESCRIPTION
Due to the private IP address block that is used for ciao tenant
networks, the subnet bits value must be a value between 12 and 30.

Fixes: #1497 

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>