### PR TITLE
ciao-deploy: When an SSH command fails report stdout/stderr

### DIFF
--- a/ciao-deploy/deploy/utils.go
+++ b/ciao-deploy/deploy/utils.go
@@ -284,7 +284,11 @@ func SSHRunCommand(ctx context.Context, user string, host string, command string
 	}
 	defer func() { _ = session.Close() }()
 
-	return session.Run(command)
+	output, err := session.CombinedOutput(command)
+	if err != nil {
+		return errors.Wrapf(err, "Error running %s on %s: %s", command, host, output)
+	}
+	return nil
 }
 
 // SSHCreateFile creates a file on a remote machine


### PR DESCRIPTION
When an SSH command generates an error (e.g. non-zero exit code) embed
the output containing the command's stdout and stderr into the error
returned. This will then be printed out as part of the detailed error
message.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>