### PR TITLE
singlevm: Do not access $GOPATH directly

### DIFF
--- a/testutil/singlevm/cleanup.sh
+++ b/testutil/singlevm/cleanup.sh
@@ -2,6 +2,7 @@
 
 . ~/local/demo.sh
 
+GOPATH=`go env GOPATH`
 ciao_gobin="$GOPATH"/bin
 ciao_host=$(hostname)
 ext_int=$(ip -o route get 8.8.8.8 | cut -d ' ' -f 5)

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -14,6 +14,7 @@ ciao_pki_path=/etc/pki/ciao
 client_auth_ca_path="$ciao_pki_path/auth-CA.pem"
 export no_proxy=$no_proxy,$ciao_vlan_ip,$ciao_host
 
+GOPATH=`go env GOPATH`
 ciao_src="$GOPATH"/src/github.com/ciao-project/ciao
 ciao_gobin="$GOPATH"/bin
 ciao_scripts="$GOPATH"/src/github.com/ciao-project/ciao/testutil/singlevm


### PR DESCRIPTION
Use "go env GOPATH" to get the desired $GOPATH if needing to use a
fallback.

Fixes: #1323

Signed-off-by: Rob Bradford <robert.bradford@intel.com>