### PR TITLE
Remove compute_fqdn

### DIFF
--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -209,14 +209,12 @@ func main() {
 		return
 	}
 
-	host := clusterConfig.Configure.Controller.ControllerFQDN
-	if host == "" {
-		host, err = getNameFromCert(httpsCAcert, httpsKey)
-		if err != nil {
-			glog.Warningf("Unable to get name from certificate: %s", err)
-			host, _ = os.Hostname()
-		}
+	host, err := getNameFromCert(httpsCAcert, httpsKey)
+	if err != nil {
+		glog.Warningf("Unable to get name from certificate: %s", err)
+		host, _ = os.Hostname()
 	}
+
 	ctl.apiURL = fmt.Sprintf("https://%s:%d", host, controllerAPIPort)
 
 	server, err := ctl.createCiaoServer()

--- a/configuration/README.md
+++ b/configuration/README.md
@@ -51,7 +51,6 @@ configure:
     compute_port: int
     compute_ca: string [The HTTPS compute endpoint CA]
     compute_cert: string [The HTTPS compute endpoint private key]
-    compute_fqdn: string [The HTTPS server fully qualified domain name, MUST match name for which compute_cert is valid]
     client_auth_ca_cert_path: string [Path to CA to verify client certificates with]
   launcher:
     compute_net: list [The launcher compute network(s)]
@@ -71,7 +70,6 @@ configure:
   controller:
     compute_ca: /etc/pki/ciao/compute_ca.pem
     compute_cert: /etc/pki/ciao/compute_key.pem
-    compute_fqdn: compute.example.com
   launcher:
     compute_net:
     - 192.168.0.0/16
@@ -91,7 +89,6 @@ configure:
     compute_port: 8774
     compute_ca: /etc/pki/ciao/compute_ca.pem
     compute_cert: /etc/pki/ciao/compute_key.pem
-    compute_fqdn: compute.example.com
   launcher:
     compute_net:
     - 192.168.0.0/16

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -58,7 +58,6 @@ const fullValidConf = `configure:
     ceph_id: ciao
   controller:
     ciao_port: 8889
-    compute_fqdn: ""
     compute_ca: /etc/pki/ciao/compute_ca.pem
     compute_cert: /etc/pki/ciao/compute_key.pem
     cnci_vcpus: 4

--- a/payloads/configure.go
+++ b/payloads/configure.go
@@ -44,7 +44,6 @@ type ConfigureScheduler struct {
 // controller service.
 type ConfigureController struct {
 	CiaoPort             int    `yaml:"ciao_port"`
-	ControllerFQDN       string `yaml:"compute_fqdn"`
 	HTTPSCACert          string `yaml:"compute_ca"`
 	HTTPSKey             string `yaml:"compute_cert"`
 	CNCIVcpus            int    `yaml:"cnci_vcpus"`

--- a/testutil/payloads.go
+++ b/testutil/payloads.go
@@ -374,7 +374,6 @@ const ConfigureYaml = `configure:
     ceph_id: ` + ManagementID + `
   controller:
     ciao_port: ` + CiaoPort + `
-    compute_fqdn: ""
     compute_ca: ` + HTTPSCACert + `
     compute_cert: ` + HTTPSKey + `
     cnci_vcpus: 0


### PR DESCRIPTION
ciao-deploy doesn't currently set this field in the configuration but for the HTTP entry points that use absolute URLs we need to something better than os.Hostname() for when controller is being reached via a FQDN.