### PR TITLE
singlevm: Fix storage tests

### DIFF
--- a/testutil/singlevm/cleanup.sh
+++ b/testutil/singlevm/cleanup.sh
@@ -21,4 +21,5 @@ sudo ip link del ciao_br
 sudo pkill -F /tmp/dnsmasq.ciaovlan.pid
 sudo docker rm -v -f ceph-demo
 sudo rm /etc/ceph/*
+sudo rm -rf /etc/ciao
 sudo rm -rf /var/lib/ciao

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -175,8 +175,12 @@ ciao-deploy setup \
 --local-launcher \
 --mgmt-net="$ciao_vlan_subnet" --compute-net="$ciao_vlan_subnet" \
 --server-ip="$ciao_vlan_ip" \
+--ceph-id="ciao" \
 --image-cache-directory="$ciao_bin"
 ciao-deploy auth create testuser
+
+# Make configuration.yaml world readable otherwise storage tests will be skipped.
+sudo chmod a+r /etc/ciao/configuration.yaml
 
 curl -O https://download.clearlinux.org/image/OVMF.fd
 sudo cp -f OVMF.fd  /usr/share/qemu/OVMF.fd


### PR DESCRIPTION
There were a number of issues with the ceph storage tests on singlevm.

1. They were not being run on new installs as /etc/ciao/configuration.yaml is
   not world readable when created by ciao-deploy.
2. cleanup.sh did not delete this file.
3. The ceph id in /etc/ciao/configuration.yaml was incorrect.  It was set to
   admin instead of ciao.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>