### PR TITLE
bat: Run some image BAT tests as non-admin user

### DIFF
--- a/_release/bat/image_bat/image_bat_test.go
+++ b/_release/bat/image_bat/image_bat_test.go
@@ -45,11 +45,16 @@ func addShowDelete(t *testing.T, visibility string) {
 	// ID, Visibility and  Name. This code needs to be updated when the image service's
 	// support for meta data improves.
 
+	var admin bool
+	if visibility == "public" || visibility == "internal" {
+		admin = true
+	}
+
 	options := bat.ImageOptions{
 		Name:       name,
 		Visibility: visibility,
 	}
-	img, err := bat.AddRandomImage(ctx, "", 10, &options)
+	img, err := bat.AddRandomImage(ctx, admin, "", 10, &options)
 	if err != nil {
 		t.Fatalf("Unable to add image %v", err)
 	}
@@ -60,19 +65,19 @@ func addShowDelete(t *testing.T, visibility string) {
 	}
 
 	if img.ID != "" {
-		gotImg, err := bat.GetImage(ctx, "", img.ID)
+		gotImg, err := bat.GetImage(ctx, admin, "", img.ID)
 		if err != nil {
 			t.Errorf("Unable to retrieve meta data for image %v", err)
 		} else if gotImg.ID != img.ID || gotImg.Name != img.Name {
 			t.Errorf("Unexpected meta data retrieved for image")
 		}
 
-		err = bat.DeleteImage(ctx, "", img.ID)
+		err = bat.DeleteImage(ctx, admin, "", img.ID)
 		if err != nil {
 			t.Fatalf("Unable to delete image %v", err)
 		}
 
-		_, err = bat.GetImage(ctx, "", img.ID)
+		_, err = bat.GetImage(ctx, admin, "", img.ID)
 		if err == nil {
 			t.Fatalf("Call to get non-existing image should fail")
 		}
@@ -101,7 +106,7 @@ func TestInternalAddShowDelete(t *testing.T) {
 // The attempt to delete the non-existing image should fail
 func TestDeleteNonExisting(t *testing.T) {
 	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
-	err := bat.DeleteImage(ctx, "", uuid.Generate().String())
+	err := bat.DeleteImage(ctx, false, "", uuid.Generate().String())
 	cancelFunc()
 	if err == nil {
 		t.Errorf("Call to delete non-existing image should fail")
@@ -121,7 +126,7 @@ func TestImageList(t *testing.T) {
 	const name = "test-image"
 	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
 	defer cancelFunc()
-	count, err := bat.GetImageCount(ctx, "")
+	count, err := bat.GetImageCount(ctx, false, "")
 	if err != nil {
 		t.Fatalf("Unable to count number of images: %v", err)
 	}
@@ -129,12 +134,12 @@ func TestImageList(t *testing.T) {
 	options := bat.ImageOptions{
 		Name: name,
 	}
-	img, err := bat.AddRandomImage(ctx, "", 10, &options)
+	img, err := bat.AddRandomImage(ctx, false, "", 10, &options)
 	if err != nil {
 		t.Fatalf("Unable to add image %v", err)
 	}
 
-	images, err := bat.GetImages(ctx, "")
+	images, err := bat.GetImages(ctx, false, "")
 	if err != nil {
 		t.Errorf("Unable to retrieve image list: %v", err)
 	}
@@ -159,7 +164,7 @@ func TestImageList(t *testing.T) {
 		t.Errorf("New image was not returned by ciao-cli image list")
 	}
 
-	err = bat.DeleteImage(ctx, "", img.ID)
+	err = bat.DeleteImage(ctx, false, "", img.ID)
 	if err != nil {
 		t.Fatalf("Unable to delete image %v", err)
 	}

--- a/_release/bat/storage_bat/storage_bat_test.go
+++ b/_release/bat/storage_bat/storage_bat_test.go
@@ -673,7 +673,7 @@ func TestCreateVolumeFromImage(t *testing.T) {
 		Name: "test-image",
 	}
 
-	image, err := bat.AddRandomImage(ctx, "", 10, &options)
+	image, err := bat.AddRandomImage(ctx, false, "", 10, &options)
 	if err != nil {
 		t.Fatalf("Unable to add image %v", err)
 	}
@@ -697,7 +697,7 @@ func TestCreateVolumeFromImage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = bat.DeleteImage(ctx, "", image.ID)
+	err = bat.DeleteImage(ctx, false, "", image.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -760,7 +760,7 @@ func TestCreateSizedVolumeFromImage(t *testing.T) {
 		Name: "test-image",
 	}
 
-	image, err := bat.AddRandomImage(ctx, "", 10, &options)
+	image, err := bat.AddRandomImage(ctx, false, "", 10, &options)
 	if err != nil {
 		t.Fatalf("Unable to add image %v", err)
 	}
@@ -784,7 +784,7 @@ func TestCreateSizedVolumeFromImage(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = bat.DeleteImage(ctx, "", image.ID)
+	err = bat.DeleteImage(ctx, false, "", image.ID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/_release/bat/workload_bat/workload_bat_test.go
+++ b/_release/bat/workload_bat/workload_bat_test.go
@@ -48,7 +48,7 @@ func getWorkloadSource(ctx context.Context, t *testing.T, tenant string) bat.Sou
 
 	// if we pass in "" for tenant, we get whatever the CIAO_USERNAME value
 	// is set to.
-	images, err := bat.GetImages(ctx, tenant)
+	images, err := bat.GetImages(ctx, false, tenant)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/bat/image.go
+++ b/bat/image.go
@@ -193,16 +193,6 @@ func GetImageCount(ctx context.Context, tenant string) (int, error) {
 	return strconv.Atoi(string(data))
 }
 
-// UploadImage overrides the contents of an existing image with a new file. It
-// is implemented by calling ciao-cli image upload. An error will be returned if
-// the following environment variables are not set; CIAO_ADMIN_CLIENT_CERT_FILE,
-// CIAO_CONTROLLER.
-func UploadImage(ctx context.Context, tenant, ID, path string) error {
-	args := []string{"image", "upload", "-image", ID, "-file", path}
-	_, err := RunCIAOCLIAsAdmin(ctx, tenant, args)
-	return err
-}
-
 // CreateRandomFile creates a file of the desired size with random data
 // returning the path.
 func CreateRandomFile(sizeMiB int) (path string, err error) {

--- a/ciao-deploy/deploy/cnci.go
+++ b/ciao-deploy/deploy/cnci.go
@@ -216,7 +216,7 @@ func CreateCNCIImage(ctx context.Context, anchorCertPath string, caCertPath stri
 	}
 
 	fmt.Printf("Uploading image as %s\n", imageOpts.ID)
-	i, err := bat.AddImage(ctx, "", preparedImage, imageOpts)
+	i, err := bat.AddImage(ctx, true, "", preparedImage, imageOpts)
 	if err != nil {
 		return errors.Wrap(err, "Error uploading image to controller")
 	}

--- a/ciao-deploy/deploy/workloads.go
+++ b/ciao-deploy/deploy/workloads.go
@@ -288,7 +288,7 @@ func (wd *baseWorkload) upload(ctx context.Context, fp, name string) error {
 	}
 
 	fmt.Printf("Uploading image from %s\n", fp)
-	i, err := bat.AddImage(ctx, "", fp, &opts)
+	i, err := bat.AddImage(ctx, true, "", fp, &opts)
 	if err != nil {
 		return errors.Wrap(err, "Error creating image")
 	}
@@ -363,7 +363,7 @@ func (wd *baseWorkload) Cleanup() {
 	}
 
 	if wd.imageID != "" {
-		_ = bat.DeleteImage(context.Background(), "", wd.imageID)
+		_ = bat.DeleteImage(context.Background(), true, "", wd.imageID)
 	}
 }
 


### PR DESCRIPTION
Previously only the admin user could create images however that is no
longer the case and the BAT tests have not been updated to reflect that.

The change in the bat package to support this added a new boolean
parameter to all bat image functions to indicate whether to run as admin
or not. This necessitated changes to the bat tests but also to
ciao-deploy that uses the bat package to upload images.

Fixes: #1520

Signed-off-by: Rob Bradford <robert.bradford@intel.com>