### PR TITLE
Qemu 2.10 and general storage fixes

### DIFF
--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -1560,113 +1560,6 @@ func TestCreateStorageAttachment(t *testing.T) {
 	}
 }
 
-func TestUpdateStorageAttachmentExisting(t *testing.T) {
-	tenant, err := addTestTenant()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	blockDevice := storage.BlockDevice{
-		ID: "validID",
-	}
-
-	data := types.BlockData{
-		BlockDevice: blockDevice,
-		State:       types.Available,
-		TenantID:    tenant.ID,
-		CreateTime:  time.Now(),
-	}
-
-	err = ds.AddBlockDevice(data)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	wls, err := ds.GetWorkloads(tenant.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(wls) == 0 {
-		t.Fatal("No Workloads Found")
-	}
-
-	instance, err := addTestInstance(tenant, wls[0])
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	volume := payloads.StorageResource{
-		ID:        data.ID,
-		Ephemeral: false,
-		Bootable:  false,
-	}
-	_, err = ds.CreateStorageAttachment(instance.ID, volume)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// get the attachments associated with this instance
-	a1 := ds.GetStorageAttachments(instance.ID)
-
-	if len(a1) != 1 {
-		t.Fatal(err)
-	}
-
-	if a1[0].InstanceID != instance.ID {
-		t.Fatal(err)
-	}
-
-	attachments := []string{data.ID}
-
-	// this doesn't return an error, but we can still exercise
-	// the code to see if anything panics.
-	ds.updateStorageAttachments(instance.ID, attachments)
-}
-
-func TestUpdateStorageAttachmentNotExisting(t *testing.T) {
-	tenant, err := addTestTenant()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	blockDevice := storage.BlockDevice{
-		ID: "validID",
-	}
-
-	data := types.BlockData{
-		BlockDevice: blockDevice,
-		State:       types.Available,
-		TenantID:    tenant.ID,
-		CreateTime:  time.Now(),
-	}
-
-	err = ds.AddBlockDevice(data)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	wls, err := ds.GetWorkloads(tenant.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(wls) == 0 {
-		t.Fatal("No Workloads Found")
-	}
-
-	instance, err := addTestInstance(tenant, wls[0])
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	attachments := []string{data.ID}
-
-	// this doesn't return an error, but we can still exercise
-	// the code to see if anything panics.
-	ds.updateStorageAttachments(instance.ID, attachments)
-}
-
 func TestUpdateStorageAttachmentDeleted(t *testing.T) {
 	tenant, err := addTestTenant()
 	if err != nil {
@@ -1713,12 +1606,7 @@ func TestUpdateStorageAttachmentDeleted(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	attachments := []string{}
-
-	// this doesn't return an error, but we can still exercise
-	// the code to see if anything panics.
-	// send in an empty list.
-	ds.updateStorageAttachments(instance.ID, attachments)
+	ds.updateStorageAttachments(instance.ID)
 }
 
 func TestGetStorageAttachment(t *testing.T) {

--- a/ciao-launcher/attachvolume_instance.go
+++ b/ciao-launcher/attachvolume_instance.go
@@ -75,7 +75,10 @@ func processAttachVolume(storageDriver storage.BlockDriver, monitorCh chan inter
 		if err != nil {
 			glog.Errorf("Unable to attach volume %s to instance %s: %v",
 				volumeUUID, instance, err)
-			_ = storageDriver.UnmapVolumeFromNode(devName)
+			unmapErr := storageDriver.UnmapVolumeFromNode(devName)
+			if unmapErr != nil {
+				glog.Warningf("Unable to unmap %s : %v", devName, unmapErr)
+			}
 			attachErr := &attachVolumeError{err, payloads.AttachVolumeAttachFailure}
 			return attachErr
 		}

--- a/ciao-launcher/qemu.go
+++ b/ciao-launcher/qemu.go
@@ -445,6 +445,9 @@ func qmpAttach(cmd virtualizerAttachCmd, q *qemu.QMP) {
 			devID, "virtio-blk-pci", "")
 		if err != nil {
 			glog.Errorf("Failed to execute device_add: %v", err)
+			if err := q.ExecuteBlockdevDel(context.Background(), blockdevID); err != nil {
+				glog.Warningf("Failed to remove block device : %v", err)
+			}
 		}
 	}
 	cmd.responseCh <- err

--- a/ciao-launcher/qemu.go
+++ b/ciao-launcher/qemu.go
@@ -426,7 +426,16 @@ func (q *qemuV) lostVM() {
 
 func qmpAttach(cmd virtualizerAttachCmd, q *qemu.QMP) {
 	glog.Info("Attach command received")
-	blockdevID := fmt.Sprintf("drive_%s", cmd.volumeUUID)
+
+	// Versions of qemu 2.9 and greater have a 31 byte limit on the size of
+	// IDs used to identify block devices.  We form our ID by appending the
+	// the volumeUUID with the '-'s and the final 3 characters removed, to the
+	// constant string "d_".  Drive names are not allowed to start with numbers.
+
+	blockdevID := fmt.Sprintf("d_%s", strings.Replace(cmd.volumeUUID, "-", "", -1))
+	if len(blockdevID) > 31 {
+		blockdevID = blockdevID[:31]
+	}
 	err := q.ExecuteBlockdevAdd(context.Background(), cmd.device, blockdevID)
 	if err != nil {
 		glog.Errorf("Failed to execute blockdev-add: %v", err)


### PR DESCRIPTION
This PR addresses storage related issues in ciao

1. Data volumes cannot be live attached to instances in qemu 2.10
2. Launcher did not always cleanup properly when a live attach failed.
3. Controller was incorrectly unattaching volumes from instances if a stats command was received from that instance while an attach command was outstanding.