### PR TITLE
 ciao-controller: when deleting tenant also delete from quota service

### DIFF
--- a/ciao-controller/internal/quotas/quotas.go
+++ b/ciao-controller/internal/quotas/quotas.go
@@ -295,38 +295,33 @@ func (qs *Quotas) Init() {
 				return
 			}
 
-			switch data.(type) {
+			switch op := data.(type) {
 
 			case *consumeOp:
-				consumeData := data.(*consumeOp)
-				res := consumeQuota(tenantDetails, consumeData)
+				res := consumeQuota(tenantDetails, op)
 				if !res.Allowed() {
-					consumeData.ch <- res
-					close(consumeData.ch)
+					op.ch <- res
+					close(op.ch)
 					continue
 				}
-				res = checkLimit(tenantDetails, consumeData)
-				consumeData.ch <- res
-				close(consumeData.ch)
+				res = checkLimit(tenantDetails, op)
+				op.ch <- res
+				close(op.ch)
 
 			case *releaseOp:
-				releaseData := data.(*releaseOp)
-				release(tenantDetails, releaseData)
+				release(tenantDetails, op)
 
 			case *updateOp:
-				updateData := data.(*updateOp)
-				update(tenantDetails, updateData)
-				close(updateData.doneCh)
+				update(tenantDetails, op)
+				close(op.doneCh)
 
 			case *dumpOp:
-				dumpData := data.(*dumpOp)
-				dumpData.ch <- dump(tenantDetails, dumpData)
-				close(dumpData.ch)
+				op.ch <- dump(tenantDetails, op)
+				close(op.ch)
 
 			case *deleteTenantOp:
-				deleteTenantData := data.(*deleteTenantOp)
-				deleteTenant(tenantDetails, deleteTenantData)
-				close(deleteTenantData.doneCh)
+				deleteTenant(tenantDetails, op)
+				close(op.doneCh)
 			}
 		}
 

--- a/ciao-controller/internal/quotas/quotas_test.go
+++ b/ciao-controller/internal/quotas/quotas_test.go
@@ -120,6 +120,42 @@ func TestTenantSeparation(t *testing.T) {
 	qs.Shutdown()
 }
 
+func TestTenantDeletion(t *testing.T) {
+	qs := &Quotas{}
+	qs.Init()
+
+	t1OrigQuotas := qs.DumpQuotas("test-tenant-1")
+
+	t1Quotas := []types.QuotaDetails{
+		{Name: "tenant-vcpu-quota", Value: 10},
+		{Name: "tenant-mem-quota", Value: 100},
+	}
+
+	qs.Update("test-tenant-1", t1Quotas)
+
+	t2Quotas := []types.QuotaDetails{
+		{Name: "tenant-vcpu-quota", Value: 20},
+		{Name: "tenant-mem-quota", Value: 40},
+	}
+
+	qs.Update("test-tenant-2", t2Quotas)
+
+	dumpedQuotas := qs.DumpQuotas("test-tenant-1")
+	testHasQuota(t, dumpedQuotas, t1Quotas[0])
+	testHasQuota(t, dumpedQuotas, t1Quotas[1])
+
+	qs.DeleteTenant("test-tenant-1")
+	dumpedQuotas = qs.DumpQuotas("test-tenant-1")
+	testHasQuota(t, dumpedQuotas, t1OrigQuotas[0])
+	testHasQuota(t, dumpedQuotas, t1OrigQuotas[1])
+
+	dumpedQuotas = qs.DumpQuotas("test-tenant-2")
+	testHasQuota(t, dumpedQuotas, t2Quotas[0])
+	testHasQuota(t, dumpedQuotas, t2Quotas[1])
+
+	qs.Shutdown()
+}
+
 func TestResourceQuotaMapping(t *testing.T) {
 	resources := []payloads.Resource{
 		payloads.VCPUs,

--- a/ciao-controller/tenants.go
+++ b/ciao-controller/tenants.go
@@ -253,6 +253,8 @@ func (c *controller) DeleteTenant(tenantID string) error {
 		}
 	}
 
-	// quotas get deleted as side effect to deleting tenant
+	c.qs.DeleteTenant(tenantID)
+
+	// quotas get deleted from database as side effect to deleting tenant
 	return c.ds.DeleteTenant(tenantID)
 }


### PR DESCRIPTION
Although the quota data was being deleted from the database it was not being deleted from the quota service. If the tenant was recreated then the quota service would have inconsistent data compared to the database.

Fixes: #1468