### PR TITLE
ciao-controller: rework tenant IP allocation

### DIFF
--- a/ciao-controller/cnci_test.go
+++ b/ciao-controller/cnci_test.go
@@ -79,6 +79,7 @@ func TestCNCIRemoved(t *testing.T) {
 
 	instanceID := instances[0].ID
 	tenantID := instances[0].TenantID
+	instance := instances[0]
 
 	// get the tenant
 	tenant, err := ctl.ds.GetTenant(tenantID)
@@ -141,7 +142,7 @@ func TestCNCIRemoved(t *testing.T) {
 
 	// call remove subnet directly to remove the cnci.
 	go func() {
-		err = tenant.CNCIctrl.RemoveSubnet(4096)
+		err = tenant.CNCIctrl.RemoveSubnet(instance.Subnet)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -48,7 +48,7 @@ func (c *controller) restartInstance(instanceID string) error {
 	}
 
 	if !i.CNCI {
-		err = t.CNCIctrl.WaitForActiveSubnetString(i.Subnet)
+		err = t.CNCIctrl.WaitForActive(i.Subnet)
 		if err != nil {
 			return errors.Wrap(err, "Error waiting for active subnet")
 		}

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -256,10 +256,12 @@ func BenchmarkNewConfig(b *testing.B) {
 
 	id := uuid.Generate()
 
+	ip := net.ParseIP("172.16.0.2")
+
 	b.ResetTimer()
 	noVolumes := []storage.BlockDevice{}
 	for n := 0; n < b.N; n++ {
-		_, err := newConfig(ctl, &wls[0], id.String(), tenant.ID, noVolumes, fmt.Sprintf("test-%d", n))
+		_, err := newConfig(ctl, &wls[0], id.String(), tenant.ID, noVolumes, fmt.Sprintf("test-%d", n), ip)
 		if err != nil {
 			b.Error(err)
 		}
@@ -1341,8 +1343,10 @@ func TestStorageConfig(t *testing.T) {
 
 	id := uuid.Generate()
 
+	ip := net.ParseIP("172.16.0.2")
+
 	noVolumes := []storage.BlockDevice{}
-	_, err = newConfig(ctl, &wls[0], id.String(), tenant.ID, noVolumes, "test")
+	_, err = newConfig(ctl, &wls[0], id.String(), tenant.ID, noVolumes, "test", ip)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -359,7 +359,7 @@ func networkConfig(ctl *controller, tenant *types.Tenant, networking *payloads.N
 
 	// send in CIDR notation?
 	networking.PrivateIP = ipAddress.String()
-	mask := net.IPv4Mask(255, 255, 255, 0)
+	mask := net.CIDRMask(tenant.SubnetBits, 32)
 	ipnet := net.IPNet{
 		IP:   ipAddress.Mask(mask),
 		Mask: mask,

--- a/ciao-controller/internal/datastore/memorydb.go
+++ b/ciao-controller/internal/datastore/memorydb.go
@@ -85,7 +85,7 @@ func (db *MemoryDB) addTenant(id string, config types.TenantConfig) error {
 			Name:       config.Name,
 			SubnetBits: config.SubnetBits,
 		},
-		network:   make(map[int]map[int]bool),
+		network:   make(map[uint32]map[uint32]bool),
 		instances: make(map[string]*types.Instance),
 		devices:   make(map[string]types.Volume),
 	}
@@ -109,11 +109,15 @@ func (db *MemoryDB) getTenants() ([]*tenant, error) {
 	return tenants, nil
 }
 
-func (db *MemoryDB) releaseTenantIP(tenantID string, subnetInt int, rest int) error {
+func (db *MemoryDB) releaseTenantIP(tenantID string, subnetInt uint32, rest uint32) error {
 	return nil
 }
 
-func (db *MemoryDB) claimTenantIP(tenantID string, subnetInt int, rest int) error {
+func (db *MemoryDB) claimTenantIP(tenantID string, subnetInt uint32, rest uint32) error {
+	return nil
+}
+
+func (db *MemoryDB) claimTenantIPs(tenantID string, IPs []tenantIP) error {
 	return nil
 }
 

--- a/ciao-controller/tenants.go
+++ b/ciao-controller/tenants.go
@@ -135,14 +135,7 @@ func (c *controller) deleteCNCIInstances(tenantID string) error {
 		go func(ID string, CIDR string) {
 			defer wg.Done()
 
-			subnet, err := subnetStringToInt(CIDR)
-			if err != nil {
-				c.client.RemoveInstance(ID)
-				glog.Warningf("Unable to remove tenant cnci: %v", err)
-				return
-			}
-
-			err = tenant.CNCIctrl.RemoveSubnet(subnet)
+			err = tenant.CNCIctrl.RemoveSubnet(CIDR)
 			if err != nil {
 				// remove directly.
 				c.client.RemoveInstance(ID)

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -786,10 +786,9 @@ type CNCIController interface {
 	CNCIStopped(id string) error
 	StartFailure(ID string) error
 	Active(ID string) bool
-	ScheduleRemoveSubnet(subnet int) error
-	RemoveSubnet(subnet int) error
-	WaitForActive(subnet int) error
-	WaitForActiveSubnetString(subnet string) error
+	ScheduleRemoveSubnet(subnet string) error
+	RemoveSubnet(subnet string) error
+	WaitForActive(subnet string) error
 	GetInstanceCNCI(InstanceID string) (*Instance, error)
 	GetSubnetCNCI(subnet string) (*Instance, error)
 	Shutdown()


### PR DESCRIPTION
The existing tenant IP allocation algorithm doesn't work unless you
have a /24 network. Rework the algorithm so that it will work with
any valid network. Also add the ability to allocate more than one
IP addresses at a time.

Fixes: #1491 

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>