### PR TITLE
ciao-controller: do not allow subnet bits to be modified if active instances

### DIFF
--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -1956,7 +1956,7 @@ func TestShowTenant(t *testing.T) {
 }
 
 func TestUpdateTenant(t *testing.T) {
-	tenant, err := addTestTenant()
+	tenant, err := addTestTenantNoCNCI()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -462,6 +462,15 @@ func (ds *Datastore) JSONPatchTenant(ID string, patch []byte) error {
 		return errors.Wrap(err, "error updating tenant")
 	}
 
+	// SubnetBits must not modified if there are active instances.
+	// for now, the cncis must also be removed. In the future we might
+	// be able to just update the cnci with the new subnet info.
+	if len(tenant.instances) > 0 {
+		if oldconfig.SubnetBits != config.SubnetBits {
+			return errors.New("Unable to update with active instances")
+		}
+	}
+
 	tenant.Name = config.Name
 	tenant.SubnetBits = config.SubnetBits
 

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -956,7 +956,15 @@ func TestGetAllTenants(t *testing.T) {
 }
 
 func TestUpdateTenant(t *testing.T) {
-	tenant, err := addTestTenant()
+	/* add a new tenant without CNCI*/
+	tuuid := uuid.Generate()
+
+	initConfig := types.TenantConfig{
+		Name:       "",
+		SubnetBits: 24,
+	}
+
+	tenant, err := ds.AddTenant(tuuid.String(), initConfig)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
A tenant network may not contained mixed networks with variable subnet bits.
Do not allow update to tenant if there are any active instances at all,
including cncis.

Fixes: #1535

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>