### PR TITLE
ciao-deploy: enable memory limits by default

### DIFF
--- a/ciao-deploy/cmd/setup.go
+++ b/ciao-deploy/cmd/setup.go
@@ -124,4 +124,5 @@ func init() {
 	setupCmd.Flags().StringVar(&imageCacheDirectory, "image-cache-directory", deploy.DefaultImageCacheDir(), "Directory to use for caching of downloaded images")
 	setupCmd.Flags().BoolVar(&force, "force", false, "Overwrite existing files which might break the cluster")
 	setupCmd.Flags().BoolVar(&localLauncher, "local-launcher", false, "Enable a local launcher on this node (for testing)")
+	setupCmd.Flags().BoolVar(&clusterConf.DisableLimits, "disable-limits", false, "Disable memory limit checking for cluster nodes")
 }

--- a/ciao-deploy/deploy/setup.go
+++ b/ciao-deploy/deploy/setup.go
@@ -45,6 +45,7 @@ type ClusterConfiguration struct {
 	AuthCACertPath    string
 	AuthAdminCertPath string
 	ServerHostname    string
+	DisableLimits     bool
 }
 
 var ciaoConfigDir = "/etc/ciao"
@@ -78,8 +79,11 @@ func createConfigurationFile(ctx context.Context, clusterConf *ClusterConfigurat
 
 	config.Configure.Launcher.ComputeNetwork = []string{clusterConf.ComputeNet}
 	config.Configure.Launcher.ManagementNetwork = []string{clusterConf.MgmtNet}
+
+	// Disk limit checking is broken and should always be disabled.
+	// See issue #1541
 	config.Configure.Launcher.DiskLimit = false
-	config.Configure.Launcher.MemoryLimit = false
+	config.Configure.Launcher.MemoryLimit = !clusterConf.DisableLimits
 
 	data, err := yaml.Marshal(config)
 	if err != nil {


### PR DESCRIPTION
Enable memory limit checking by launcher by default,
and only disable if --disable-limits is passed to ciao-deploy setup.

Fixes: #1539 

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>