### PR TITLE
ciao-controller: sqlitedb: initialize Instance StateChange

### DIFF
--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -1181,6 +1181,8 @@ func (ds *sqliteDB) getInstances() ([]*types.Instance, error) {
 			i.SSHPort = int(sshPort.Int64)
 		}
 
+		i.StateChange = sync.NewCond(&sync.Mutex{})
+
 		instances = append(instances, &i)
 	}
 
@@ -1258,6 +1260,8 @@ func (ds *sqliteDB) getTenantInstances(tenantID string) (map[string]*types.Insta
 		if sshPort.Valid {
 			i.SSHPort = int(sshPort.Int64)
 		}
+
+		i.StateChange = sync.NewCond(&sync.Mutex{})
 
 		instances[i.ID] = i
 	}


### PR DESCRIPTION
initialize the StateChange condition variable when creating
instance structs.

Fixes: #1547

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>