### PR TITLE
ciao-controller: report errors properly when setting logDirFlag value

### DIFF
--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -85,8 +85,10 @@ func init() {
 	}
 
 	if logDirFlag.Value.String() == "" {
-		err := logDirFlag.Value.Set(logDir)
-		glog.Errorf("Error setting log directory: %v", err)
+		if err := logDirFlag.Value.Set(logDir); err != nil {
+			glog.Errorf("Error setting log directory: %v", err)
+			return
+		}
 	}
 
 	if err := os.MkdirAll(logDirFlag.Value.String(), 0755); err != nil {


### PR DESCRIPTION
If logDirFlag fails to set, we should report the error and exit.
If it does not fail to set, we should not report an error.

Fixes: #1552

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>