### PR TITLE
Preparatory work for ciao-deploy cleanup

### DIFF
--- a/ciao-controller/api.go
+++ b/ciao-controller/api.go
@@ -231,11 +231,6 @@ func getResources(c *controller, w http.ResponseWriter, r *http.Request) (APIRes
 	vars := mux.Vars(r)
 	tenant := vars["tenant"]
 
-	err := c.confirmTenant(tenant)
-	if err != nil {
-		return errorResponse(err), err
-	}
-
 	t, err := c.ds.GetTenant(tenant)
 	if err != nil || t == nil {
 		return errorResponse(types.ErrTenantNotFound), types.ErrTenantNotFound

--- a/ciao-controller/client.go
+++ b/ciao-controller/client.go
@@ -147,7 +147,7 @@ func (client *ssntpClient) RemoveInstance(instanceID string) {
 	}
 
 	// notify anyone is listening for a state change
-	err = transitionInstanceState(i, payloads.Deleted)
+	err = i.TransitionInstanceState(payloads.Deleted)
 	if err != nil {
 		glog.Warningf("Error transitioning CNCI to deleted: %v", err)
 	}

--- a/ciao-controller/cnci.go
+++ b/ciao-controller/cnci.go
@@ -74,7 +74,7 @@ type CNCIManager struct {
 }
 
 func (c *CNCI) stop() error {
-	err := transitionInstanceState(c.instance, payloads.Stopping)
+	err := c.instance.TransitionInstanceState(payloads.Stopping)
 	if err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func waitForEventTimeout(ch chan event, e event, timeout time.Duration) error {
 func (c *CNCI) transitionState(to CNCIState) {
 	glog.Infof("State transition to %s received for %s", to, c.instance.ID)
 
-	err := transitionInstanceState(c.instance, (string(to)))
+	err := c.instance.TransitionInstanceState(string(to))
 	if err != nil {
 		glog.Warningf("Error transitioning instance %s to %s state", c.instance.ID, string(to))
 	}

--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -238,11 +238,6 @@ func (c *controller) startWorkload(w types.WorkloadRequest) ([]*types.Instance, 
 		return nil, err
 	}
 
-	err = c.confirmTenant(w.TenantID)
-	if err != nil {
-		return nil, err
-	}
-
 	var newInstances []*types.Instance
 
 	for i := 0; i < w.Instances && e == nil; i++ {

--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -124,7 +124,7 @@ func (c *controller) deleteInstanceSync(instanceID string) error {
 	case <-wait:
 		return nil
 	case <-time.After(2 * time.Minute):
-		err = transitionInstanceState(i, payloads.Hung)
+		err = i.TransitionInstanceState(payloads.Hung)
 		if err != nil {
 			glog.Warningf("Error transitioning instance to hung state: %v", err)
 		}

--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -186,31 +186,6 @@ func (i *instance) Allowed() (bool, error) {
 	return res.Allowed(), nil
 }
 
-func transitionInstanceState(i *types.Instance, to string) error {
-	i.StateLock.Lock()
-	defer i.StateLock.Unlock()
-
-	glog.V(2).Infof("Instance %s: %s -> %s", i.ID, i.State, to)
-
-	switch to {
-	case payloads.Stopping:
-		if i.State != payloads.Running {
-			return errors.New("Stop operation not allowed")
-		}
-	case payloads.Running:
-		if i.State != payloads.Pending {
-			return errors.New("Set active without pending")
-		}
-	}
-
-	i.StateChange.L.Lock()
-	i.State = to
-	i.StateChange.L.Unlock()
-	i.StateChange.Signal()
-
-	return nil
-}
-
 func instanceActive(i *types.Instance) bool {
 	i.StateLock.RLock()
 	defer i.StateLock.RUnlock()

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -1233,6 +1233,10 @@ func (ds *Datastore) InstanceStopped(instanceID string) error {
 // DeleteNode removes a node from the node cache.
 func (ds *Datastore) DeleteNode(nodeID string) error {
 	ds.nodesLock.Lock()
+	for _, i := range ds.nodes[nodeID].instances {
+		_ = i.TransitionInstanceState(payloads.Missing)
+		i.NodeID = ""
+	}
 	delete(ds.nodes, nodeID)
 	ds.nodesLock.Unlock()
 

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -1159,7 +1159,7 @@ func (ds *Datastore) DeleteInstance(instanceID string) error {
 	msg := fmt.Sprintf("Deleted Instance %s", instanceID)
 	e := types.LogEntry{
 		TenantID:  tenantID,
-		EventType: string(userError),
+		EventType: string(userInfo),
 		Message:   msg,
 		NodeID:    nodeID,
 	}

--- a/ciao-controller/tenants.go
+++ b/ciao-controller/tenants.go
@@ -234,7 +234,7 @@ func (c *controller) DeleteTenant(tenantID string) error {
 		if i.Visibility == types.Public {
 			continue
 		}
-		err := c.ds.DeleteImage(i.ID)
+		err := c.DeleteImage(tenantID, i.ID)
 		if err != nil {
 			return errors.Wrap(err, "Unable to remove tenant")
 		}

--- a/ciao-controller/volume.go
+++ b/ciao-controller/volume.go
@@ -27,13 +27,9 @@ import (
 
 // CreateVolume will create a new block device and store it in the datastore.
 func (c *controller) CreateVolume(tenant string, req api.RequestedVolume) (types.Volume, error) {
-	err := c.confirmTenant(tenant)
-	if err != nil {
-		return types.Volume{}, err
-	}
-
 	var bd storage.BlockDevice
 
+	var err error
 	// no limits checking for now.
 	if req.ImageRef != "" {
 		// create bootable volume
@@ -92,11 +88,6 @@ func (c *controller) CreateVolume(tenant string, req api.RequestedVolume) (types
 }
 
 func (c *controller) DeleteVolume(tenant string, volume string) error {
-	err := c.confirmTenant(tenant)
-	if err != nil {
-		return err
-	}
-
 	// get the block device information
 	info, err := c.ds.GetBlockDevice(volume)
 	if err != nil {
@@ -134,11 +125,6 @@ func (c *controller) DeleteVolume(tenant string, volume string) error {
 }
 
 func (c *controller) AttachVolume(tenant string, volume string, instance string, mountpoint string) error {
-	err := c.confirmTenant(tenant)
-	if err != nil {
-		return err
-	}
-
 	// get the block device information
 	info, err := c.ds.GetBlockDevice(volume)
 	if err != nil {
@@ -200,11 +186,6 @@ func (c *controller) AttachVolume(tenant string, volume string, instance string,
 }
 
 func (c *controller) DetachVolume(tenant string, volume string, attachment string) error {
-	err := c.confirmTenant(tenant)
-	if err != nil {
-		return err
-	}
-
 	// we don't support detaching by attachment ID yet.
 	if attachment != "" {
 		return errors.New("Detaching by attachment ID not implemented")
@@ -282,11 +263,6 @@ func (c *controller) DetachVolume(tenant string, volume string, attachment strin
 func (c *controller) ListVolumesDetail(tenant string) ([]types.Volume, error) {
 	vols := []types.Volume{}
 
-	err := c.confirmTenant(tenant)
-	if err != nil {
-		return vols, err
-	}
-
 	devs, err := c.ds.GetBlockDevices(tenant)
 	if err != nil {
 		return vols, err
@@ -304,11 +280,6 @@ func (c *controller) ListVolumesDetail(tenant string) ([]types.Volume, error) {
 }
 
 func (c *controller) ShowVolumeDetails(tenant string, volume string) (types.Volume, error) {
-	err := c.confirmTenant(tenant)
-	if err != nil {
-		return types.Volume{}, err
-	}
-
 	vol, err := c.ds.GetBlockDevice(volume)
 	if err != nil {
 		return types.Volume{}, err

--- a/ciao-controller/workload.go
+++ b/ciao-controller/workload.go
@@ -166,11 +166,6 @@ func (c *controller) CreateWorkload(req types.Workload) (types.Workload, error) 
 		return req, err
 	}
 
-	err = c.confirmTenant(req.TenantID)
-	if err != nil {
-		return req, err
-	}
-
 	req.ID = uuid.Generate().String()
 
 	err = c.ds.AddWorkload(req)

--- a/ciao-deploy/deploy/auth.go
+++ b/ciao-deploy/deploy/auth.go
@@ -113,7 +113,7 @@ func CreateAdminCert(ctx context.Context, force bool) (_ string, _ string, errOu
 	if !force {
 		if _, err := os.Stat(caCertPath); err == nil {
 			if _, err := os.Stat(certPath); err == nil {
-				fmt.Printf("Authentication certificates already installed. Skipping creation.")
+				fmt.Println("Authentication certificates already installed. Skipping creation.")
 				return caCertPath, certPath, nil
 			} else if !os.IsNotExist(err) {
 				return "", "", errors.Wrap(err, "Error stat()ing cert file")

--- a/ciao-deploy/deploy/workloads.go
+++ b/ciao-deploy/deploy/workloads.go
@@ -283,12 +283,11 @@ func (cwd *clearWorkload) Extra() bool {
 
 func (wd *baseWorkload) upload(ctx context.Context, fp, name string) error {
 	opts := bat.ImageOptions{
-		Name:       name,
-		Visibility: "public",
+		Name: name,
 	}
 
 	fmt.Printf("Uploading image from %s\n", fp)
-	i, err := bat.AddImage(ctx, true, "", fp, &opts)
+	i, err := bat.AddImage(ctx, false, "", fp, &opts)
 	if err != nil {
 		return errors.Wrap(err, "Error creating image")
 	}

--- a/payloads/stats.go
+++ b/payloads/stats.go
@@ -148,6 +148,10 @@ const (
 
 	// Hung indicates that an instance is not responding to commands.
 	Hung = "hung"
+
+	// Missing indicates that the node this instance is running on is not
+	// active
+	Missing = "missing"
 )
 
 // Init initialises instances of the Stat structure.


### PR DESCRIPTION
In order to implement ciao-deploy cleanup i've decided to use tenant deletion to cleanup up resources consumed by the cluster. In order to do that it was necessary to:

* Delete instances even if the node has been unjoined (by updating their state to "missing" if the node goes away)
*  Delete the image data and metadata

This PR also fixes some other bugs: #1543 and #1551