### PR TITLE
ciao-controller: Fix reporting level for instance deleted events

### DIFF
--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -1159,7 +1159,7 @@ func (ds *Datastore) DeleteInstance(instanceID string) error {
 	msg := fmt.Sprintf("Deleted Instance %s", instanceID)
 	e := types.LogEntry{
 		TenantID:  tenantID,
-		EventType: string(userError),
+		EventType: string(userInfo),
 		Message:   msg,
 		NodeID:    nodeID,
 	}


### PR DESCRIPTION
Log instance deleted events as event rather than errors.

Fixes: #1551

Signed-off-by: Rob Bradford <robert.bradford@intel.com>