### PR TITLE
ciao-controller: Delete image metadata and data

### DIFF
--- a/ciao-controller/tenants.go
+++ b/ciao-controller/tenants.go
@@ -234,7 +234,7 @@ func (c *controller) DeleteTenant(tenantID string) error {
 		if i.Visibility == types.Public {
 			continue
 		}
-		err := c.ds.DeleteImage(i.ID)
+		err := c.DeleteImage(tenantID, i.ID)
 		if err != nil {
 			return errors.Wrap(err, "Unable to remove tenant")
 		}


### PR DESCRIPTION
When deleting a tenant delete both the image metadata and the image data
itself.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>