### PR TITLE
Remove "public" tenant

### DIFF
--- a/ciao-controller/api/api.go
+++ b/ciao-controller/api/api.go
@@ -674,8 +674,10 @@ func addWorkload(c *Context, w http.ResponseWriter, r *http.Request) (Response, 
 	tenantID, ok := vars["tenant"]
 	if ok {
 		req.TenantID = tenantID
+		req.Visibility = types.Private
 	} else {
 		req.TenantID = "public"
+		req.Visibility = types.Public
 	}
 
 	wl, err := c.CreateWorkload(req)

--- a/ciao-controller/api/api.go
+++ b/ciao-controller/api/api.go
@@ -672,11 +672,10 @@ func addWorkload(c *Context, w http.ResponseWriter, r *http.Request) (Response, 
 	// for their own tenant.
 	vars := mux.Vars(r)
 	tenantID, ok := vars["tenant"]
+	req.TenantID = tenantID
 	if ok {
-		req.TenantID = tenantID
 		req.Visibility = types.Private
 	} else {
-		req.TenantID = "public"
 		req.Visibility = types.Public
 	}
 
@@ -710,10 +709,9 @@ func deleteWorkload(c *Context, w http.ResponseWriter, r *http.Request) (Respons
 	vars := mux.Vars(r)
 	ID := vars["workload_id"]
 
-	// if we have no tenant variable, then we are admin
 	tenantID, ok := vars["tenant"]
 	if !ok {
-		tenantID = "public"
+		tenantID = "admin"
 	}
 
 	err := c.DeleteWorkload(tenantID, ID)
@@ -728,10 +726,9 @@ func showWorkload(c *Context, w http.ResponseWriter, r *http.Request) (Response,
 	vars := mux.Vars(r)
 	ID := vars["workload_id"]
 
-	// if we have no tenant variable, then we are admin
 	tenant, ok := vars["tenant"]
 	if !ok {
-		tenant = "public"
+		tenant = "admin"
 	}
 
 	wl, err := c.ShowWorkload(tenant, ID)
@@ -745,11 +742,7 @@ func showWorkload(c *Context, w http.ResponseWriter, r *http.Request) (Response,
 func listWorkloads(c *Context, w http.ResponseWriter, r *http.Request) (Response, error) {
 	vars := mux.Vars(r)
 
-	// if we have no tenant variable, then we are admin
-	tenant, ok := vars["tenant"]
-	if !ok {
-		tenant = "public"
-	}
+	tenant := vars["tenant"]
 
 	wls, err := c.ListWorkloads(tenant)
 	if err != nil {

--- a/ciao-controller/api/api_test.go
+++ b/ciao-controller/api/api_test.go
@@ -133,7 +133,7 @@ var tests = []test{
 		`{"id":"","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_name":"","config":"this will totally work!","defaults":[]}`,
 		fmt.Sprintf("application/%s", WorkloadsV1),
 		http.StatusCreated,
-		`{"workload":{"id":"ba58f471-0735-4773-9550-188e2d012941","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_name":"","config":"this will totally work!","defaults":[],"storage":null},"link":{"rel":"self","href":"/workloads/ba58f471-0735-4773-9550-188e2d012941"}}`,
+		`{"workload":{"id":"ba58f471-0735-4773-9550-188e2d012941","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_name":"","config":"this will totally work!","defaults":[],"storage":null,"visibility":"public"},"link":{"rel":"self","href":"/workloads/ba58f471-0735-4773-9550-188e2d012941"}}`,
 	},
 	{
 		"DELETE",
@@ -149,7 +149,7 @@ var tests = []test{
 		"",
 		fmt.Sprintf("application/%s", WorkloadsV1),
 		http.StatusOK,
-		`{"id":"ba58f471-0735-4773-9550-188e2d012941","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_name":"","config":"this will totally work!","defaults":null,"storage":null}`,
+		`{"id":"ba58f471-0735-4773-9550-188e2d012941","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_name":"","config":"this will totally work!","defaults":null,"storage":null,"visibility":"private"}`,
 	},
 	{
 		"GET",
@@ -157,7 +157,7 @@ var tests = []test{
 		"",
 		fmt.Sprintf("application/%s", WorkloadsV1),
 		http.StatusOK,
-		`[{"id":"ba58f471-0735-4773-9550-188e2d012941","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_name":"","config":"this will totally work!","defaults":null,"storage":null}]`,
+		`[{"id":"ba58f471-0735-4773-9550-188e2d012941","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_name":"","config":"this will totally work!","defaults":null,"storage":null,"visibility":"private"}]`,
 	},
 	{
 		"GET",
@@ -456,6 +456,7 @@ func (ts testCiaoService) ShowWorkload(tenant string, ID string) (types.Workload
 		FWType:      payloads.Legacy,
 		VMType:      payloads.QEMU,
 		Config:      "this will totally work!",
+		Visibility:  types.Private,
 	}, nil
 }
 
@@ -468,6 +469,7 @@ func (ts testCiaoService) ListWorkloads(tenant string) ([]types.Workload, error)
 			FWType:      payloads.Legacy,
 			VMType:      payloads.QEMU,
 			Config:      "this will totally work!",
+			Visibility:  types.Private,
 		},
 	}, nil
 }

--- a/ciao-controller/client.go
+++ b/ciao-controller/client.go
@@ -104,7 +104,7 @@ func (client *ssntpClient) releaseResources(instanceID string) error {
 		return nil
 	}
 
-	wl, err := client.ctl.ds.GetWorkload(i.TenantID, i.WorkloadID)
+	wl, err := client.ctl.ds.GetWorkload(i.WorkloadID)
 	if err != nil {
 		return errors.Wrapf(err, "error getting workload for instance from datastore")
 	}

--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -39,7 +39,7 @@ func (c *controller) restartInstance(instanceID string) error {
 		return errors.New("You may only restart paused instances")
 	}
 
-	w, err := c.ds.GetWorkload(i.TenantID, i.WorkloadID)
+	w, err := c.ds.GetWorkload(i.WorkloadID)
 	if err != nil {
 		return err
 	}
@@ -276,7 +276,7 @@ func (c *controller) startWorkload(w types.WorkloadRequest) ([]*types.Instance, 
 		return nil, errors.New("Missing number of instances to start")
 	}
 
-	wl, err := c.ds.GetWorkload(w.TenantID, w.WorkloadID)
+	wl, err := c.ds.GetWorkload(w.WorkloadID)
 	if err != nil {
 		return nil, err
 	}

--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -149,7 +149,7 @@ func (i *instance) Clean() error {
 		return errors.Wrap(err, "error releasing tenant IP")
 	}
 
-	wl, err := i.ctl.ds.GetWorkload(i.TenantID, i.WorkloadID)
+	wl, err := i.ctl.ds.GetWorkload(i.WorkloadID)
 	if err != nil {
 		return errors.Wrap(err, "error getting workload from datastore")
 	}
@@ -173,7 +173,7 @@ func (i *instance) Allowed() (bool, error) {
 
 	ds := i.ctl.ds
 
-	wl, err := ds.GetWorkload(i.TenantID, i.WorkloadID)
+	wl, err := ds.GetWorkload(i.WorkloadID)
 	if err != nil {
 		return true, errors.Wrap(err, "error getting workload from datastore")
 	}

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -2539,6 +2539,7 @@ users:
 		Config:      config,
 		Defaults:    []payloads.RequestedResource{cpus, mem, network},
 		Storage:     []types.StorageResource{storage},
+		Visibility:  types.Internal,
 	}
 
 	// for now we have a single global cnci workload.

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -93,7 +93,7 @@ type persistentStore interface {
 	getEventLog() (logEntries []*types.LogEntry, err error)
 
 	// interfaces related to workloads
-	updateWorkload(wl types.Workload) error
+	addWorkload(wl types.Workload) error
 	deleteWorkload(ID string) error
 
 	// interfaces related to tenants
@@ -493,7 +493,7 @@ func (ds *Datastore) AddWorkload(w types.Workload) error {
 		return ErrNoTenant
 	}
 
-	err := ds.db.updateWorkload(w)
+	err := ds.db.addWorkload(w)
 	if err != nil {
 		return errors.Wrapf(err, "error updating workload (%v) in database", w.ID)
 	}

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -2556,7 +2556,7 @@ func TestDeleteWorkload(t *testing.T) {
 	}
 
 	// attempt to delete this workload, should fail.
-	err = ds.DeleteWorkload(tenant.ID, wls[0].ID)
+	err = ds.DeleteWorkload(wls[0].ID)
 	if err != types.ErrWorkloadInUse {
 		t.Fatal("Deleting an in use workload did not fail")
 	}
@@ -2567,7 +2567,7 @@ func TestDeleteWorkload(t *testing.T) {
 	}
 
 	// attempt to delete this workload, should pass
-	err = ds.DeleteWorkload(tenant.ID, wls[0].ID)
+	err = ds.DeleteWorkload(wls[0].ID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ciao-controller/internal/datastore/memorydb.go
+++ b/ciao-controller/internal/datastore/memorydb.go
@@ -229,6 +229,10 @@ func (db *MemoryDB) deleteWorkload(ID string) error {
 	return nil
 }
 
+func (db *MemoryDB) getWorkloads() ([]types.Workload, error) {
+	return []types.Workload{}, nil
+}
+
 func (db *MemoryDB) updateQuotas(tenantID string, qds []types.QuotaDetails) error {
 	return nil
 }

--- a/ciao-controller/internal/datastore/memorydb.go
+++ b/ciao-controller/internal/datastore/memorydb.go
@@ -221,7 +221,7 @@ func (db *MemoryDB) getMappedIPs() map[string]types.MappedIP {
 	return make(map[string]types.MappedIP)
 }
 
-func (db *MemoryDB) updateWorkload(wl types.Workload) error {
+func (db *MemoryDB) addWorkload(wl types.Workload) error {
 	return nil
 }
 

--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -870,19 +870,17 @@ func (ds *sqliteDB) addWorkload(w types.Workload) error {
 	}
 
 	// add in any workload storage resources
-	if len(w.Storage) > 0 {
-		for i := range w.Storage {
-			err := ds.createWorkloadStorage(tx, w.ID, &w.Storage[i])
-			if err != nil {
-				_ = tx.Rollback()
-				return err
-			}
+	for i := range w.Storage {
+		err := ds.createWorkloadStorage(tx, w.ID, &w.Storage[i])
+		if err != nil {
+			_ = tx.Rollback()
+			return err
 		}
 	}
 
 	// write config to file.
 	filename := fmt.Sprintf("%s_config.yaml", w.ID)
-	path := fmt.Sprintf("%s/%s", ds.workloadsPath, filename)
+	path := filepath.Join(ds.workloadsPath, filename)
 	err = ioutil.WriteFile(path, []byte(w.Config), 0644)
 	if err != nil {
 		_ = tx.Rollback()

--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -782,12 +782,10 @@ func (ds *sqliteDB) getTenant(ID string) (*tenant, error) {
 		glog.V(2).Info(err)
 	}
 
-	t.workloads, err = ds.getTenantWorkloads(t.ID)
-
 	return t, err
 }
 
-func (ds *sqliteDB) getTenantWorkloads(tenantID string) ([]types.Workload, error) {
+func (ds *sqliteDB) getWorkloads() ([]types.Workload, error) {
 	var workloads []types.Workload
 
 	db := ds.db
@@ -799,11 +797,9 @@ func (ds *sqliteDB) getTenantWorkloads(tenantID string) ([]types.Workload, error
 			 vm_type,
 			 image_name,
 			 visibility
-		  FROM workload_template
-		  WHERE tenant_id = ?`
+		  FROM workload_template`
 
-	// handle case where tenant simply doesn't have any workloads.
-	rows, err := db.Query(query, tenantID)
+	rows, err := db.Query(query)
 	if err != nil {
 		return nil, err
 	}
@@ -845,9 +841,11 @@ func (ds *sqliteDB) getTenantWorkloads(tenantID string) ([]types.Workload, error
 
 		workloads = append(workloads, wl)
 	}
+
 	if err = rows.Err(); err != nil {
 		return nil, err
 	}
+
 	return workloads, nil
 }
 
@@ -987,11 +985,6 @@ func (ds *sqliteDB) getTenants() ([]*tenant, error) {
 		}
 
 		t.devices, err = ds.getTenantDevices(t.ID)
-		if err != nil {
-			return nil, err
-		}
-
-		t.workloads, err = ds.getTenantWorkloads(t.ID)
 		if err != nil {
 			return nil, err
 		}

--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -246,8 +246,7 @@ func (d workloadTemplateData) Init() error {
 		fw_type text,
 		vm_type text,
 		image_name text,
-		internal integer,
-		foreign key(tenant_id) references tenants(id)
+		internal integer
 		);`
 
 	return d.ds.exec(d.db, cmd)

--- a/ciao-controller/internal/datastore/sqlite3db_test.go
+++ b/ciao-controller/internal/datastore/sqlite3db_test.go
@@ -981,16 +981,18 @@ users:
 		t.Fatal(err)
 	}
 
-	tenant, err := db.getTenant(tn.ID)
+	workloads, err := db.getWorkloads()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if len(tenant.workloads) != 1 {
-		t.Fatal("Expected a workload associated with tenant")
+	var wl2 types.Workload
+	for i, w := range workloads {
+		if w.ID == wl.ID {
+			wl2 = workloads[i]
+			break
+		}
 	}
-
-	wl2 := tenant.workloads[0]
 
 	if !reflect.DeepEqual(wl, wl2) {
 		fmt.Fprintf(os.Stderr, "got %v\n", wl2)
@@ -1004,13 +1006,13 @@ users:
 		t.Fatal(err)
 	}
 
-	tenant, err = db.getTenant(tn.ID)
+	workloads, err = db.getWorkloads()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if len(tenant.workloads) != 0 {
-		t.Fatal("Expected no workloads associated with tenant")
+	if len(workloads) != 0 {
+		t.Fatal("Expected no workloads")
 	}
 
 	db.disconnect()

--- a/ciao-controller/internal/datastore/sqlite3db_test.go
+++ b/ciao-controller/internal/datastore/sqlite3db_test.go
@@ -976,7 +976,7 @@ users:
 	filename := fmt.Sprintf("%s/%s_config.yaml", *workloadsPath, wl.ID)
 	defer func() { _ = os.Remove(filename) }()
 
-	err = db.updateWorkload(wl)
+	err = db.addWorkload(wl)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ciao-controller/quotas.go
+++ b/ciao-controller/quotas.go
@@ -75,7 +75,7 @@ func populateQuotasFromDatastore(qs *quotas.Quotas, ds *datastore.Datastore) err
 		}
 
 		for _, instance := range instances {
-			wl, err := ds.GetWorkload(t.ID, instance.WorkloadID)
+			wl, err := ds.GetWorkload(instance.WorkloadID)
 			if err != nil {
 				return errors.Wrapf(err, "error getting workload")
 			}

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -88,6 +88,7 @@ type Workload struct {
 	Config      string                       `json:"config"`
 	Defaults    []payloads.RequestedResource `json:"defaults"`
 	Storage     []StorageResource            `json:"storage"`
+	Visibility  Visibility                   `json:"visibility"`
 }
 
 // WorkloadResponse will be returned from /workloads apis


### PR DESCRIPTION
Copy the methodology used for images onto workloads allowing us to remove the pseudo-tenant "public". Workloads gain a visibility field which is persisted into the database and the cache is modified to have slices of IDs for workloads associated with a given tenant or which are public.

Fixes: #1328 