### PR TITLE
 ciao-controller: Mark instances as missing when node is deleted

### DIFF
--- a/ciao-controller/client.go
+++ b/ciao-controller/client.go
@@ -147,7 +147,7 @@ func (client *ssntpClient) RemoveInstance(instanceID string) {
 	}
 
 	// notify anyone is listening for a state change
-	err = transitionInstanceState(i, payloads.Deleted)
+	err = i.TransitionInstanceState(payloads.Deleted)
 	if err != nil {
 		glog.Warningf("Error transitioning CNCI to deleted: %v", err)
 	}

--- a/ciao-controller/cnci.go
+++ b/ciao-controller/cnci.go
@@ -72,7 +72,7 @@ type CNCIManager struct {
 }
 
 func (c *CNCI) stop() error {
-	err := transitionInstanceState(c.instance, payloads.Stopping)
+	err := c.instance.TransitionInstanceState(payloads.Stopping)
 	if err != nil {
 		return err
 	}
@@ -100,7 +100,7 @@ func waitForEventTimeout(ch chan event, e event, timeout time.Duration) error {
 func (c *CNCI) transitionState(to CNCIState) {
 	glog.Infof("State transition to %s received for %s", to, c.instance.ID)
 
-	err := transitionInstanceState(c.instance, (string(to)))
+	err := c.instance.TransitionInstanceState(string(to))
 	if err != nil {
 		glog.Warningf("Error transitioning instance %s to %s state", c.instance.ID, string(to))
 	}

--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -126,7 +126,7 @@ func (c *controller) deleteInstanceSync(instanceID string) error {
 	case <-wait:
 		return nil
 	case <-time.After(2 * time.Minute):
-		err = transitionInstanceState(i, payloads.Hung)
+		err = i.TransitionInstanceState(payloads.Hung)
 		if err != nil {
 			glog.Warningf("Error transitioning instance to hung state: %v", err)
 		}

--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -146,6 +146,10 @@ func (c *controller) deleteInstance(instanceID string) error {
 		return types.ErrInstanceNotAssigned
 	}
 
+	if i.State == payloads.Missing {
+		return types.ErrInstanceNotAssigned
+	}
+
 	// check for any external IPs
 	IPs := c.ds.GetMappedIPs(&i.TenantID)
 	for _, m := range IPs {

--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -186,31 +186,6 @@ func (i *instance) Allowed() (bool, error) {
 	return res.Allowed(), nil
 }
 
-func transitionInstanceState(i *types.Instance, to string) error {
-	i.StateLock.Lock()
-	defer i.StateLock.Unlock()
-
-	glog.V(2).Infof("Instance %s: %s -> %s", i.ID, i.State, to)
-
-	switch to {
-	case payloads.Stopping:
-		if i.State != payloads.Running {
-			return errors.New("Stop operation not allowed")
-		}
-	case payloads.Running:
-		if i.State != payloads.Pending {
-			return errors.New("Set active without pending")
-		}
-	}
-
-	i.StateChange.L.Lock()
-	i.State = to
-	i.StateChange.L.Unlock()
-	i.StateChange.Signal()
-
-	return nil
-}
-
 func instanceActive(i *types.Instance) bool {
 	i.StateLock.RLock()
 	defer i.StateLock.RUnlock()

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -1291,6 +1291,10 @@ func (ds *Datastore) InstanceStopped(instanceID string) error {
 // DeleteNode removes a node from the node cache.
 func (ds *Datastore) DeleteNode(nodeID string) error {
 	ds.nodesLock.Lock()
+	for _, i := range ds.nodes[nodeID].instances {
+		_ = i.TransitionInstanceState(payloads.Missing)
+		i.NodeID = ""
+	}
 	delete(ds.nodes, nodeID)
 	ds.nodesLock.Unlock()
 

--- a/payloads/stats.go
+++ b/payloads/stats.go
@@ -148,6 +148,10 @@ const (
 
 	// Hung indicates that an instance is not responding to commands.
 	Hung = "hung"
+
+	// Missing indicates that the node this instance is running on is not
+	// active
+	Missing = "missing"
 )
 
 // Init initialises instances of the Stat structure.


### PR DESCRIPTION
When a node is deleted from the database mark the instance as missing
and reset the node ID associated with the instance. If the node comes
back then the instance will be transitioned to active again by the
stats being received.
