### PR TITLE
ciao-controller: Initialise workloads correctly on restart

### DIFF
--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -271,7 +271,7 @@ func (ds *Datastore) initWorkloads() error {
 				return errors.Wrapf(err, "Database inconsistent: tenant in workload not in database: %s", wl.TenantID)
 			}
 
-			ds.tenants[wl.TenantID].images = append(ds.tenants[wl.TenantID].images, wl.ID)
+			ds.tenants[wl.TenantID].workloads = append(ds.tenants[wl.TenantID].workloads, wl.ID)
 		}
 	}
 


### PR DESCRIPTION
This commit fixes a small bug in which images and workloads were corrupted in
the controller cache after a service restart.  The workloads were being added
to the images slice by mistake.

Fixes: https://github.com/ciao-project/ciao/issues/1576

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>