### PR TITLE
ciao-controller: Use payload.WorkloadRequirements in types.Workload

### DIFF
--- a/_release/bat/base_bat/base_bat_test.go
+++ b/_release/bat/base_bat/base_bat_test.go
@@ -380,7 +380,7 @@ func TestStartBadWorkload(t *testing.T) {
 		Description: "BAD Workload test",
 		VMType:      payloads.Docker,
 		ImageName:   uuid.Generate().String(),
-		Defaults: bat.DefaultResources{
+		Requirements: bat.WorkloadRequirements{
 			VCPUs: 2,
 			MemMB: 128,
 		},

--- a/_release/bat/workload_bat/workload_bat_test.go
+++ b/_release/bat/workload_bat/workload_bat_test.go
@@ -79,7 +79,7 @@ func testCreateWorkload(t *testing.T, public bool) {
 	source := getWorkloadSource(ctx, t, tenant)
 
 	// fill out the opt structure for this workload.
-	defaults := bat.DefaultResources{
+	requirements := bat.WorkloadRequirements{
 		VCPUs: 2,
 		MemMB: 128,
 	}
@@ -91,11 +91,11 @@ func testCreateWorkload(t *testing.T, public bool) {
 	}
 
 	opt := bat.WorkloadOptions{
-		Description: "BAT VM Test",
-		VMType:      "qemu",
-		FWType:      "legacy",
-		Defaults:    defaults,
-		Disks:       []bat.Disk{disk},
+		Description:  "BAT VM Test",
+		VMType:       "qemu",
+		FWType:       "legacy",
+		Requirements: requirements,
+		Disks:        []bat.Disk{disk},
 	}
 
 	var ID string
@@ -116,7 +116,7 @@ func testCreateWorkload(t *testing.T, public bool) {
 		t.Fatal(err)
 	}
 
-	if w.Name != opt.Description || w.CPUs != opt.Defaults.VCPUs || w.Mem != opt.Defaults.MemMB {
+	if w.Name != opt.Description || w.CPUs != opt.Requirements.VCPUs || w.Mem != opt.Requirements.MemMB {
 		t.Fatalf("Workload not defined correctly")
 	}
 
@@ -183,7 +183,7 @@ func TestCreateWorkloadWithSizedVolume(t *testing.T) {
 
 	source := getWorkloadSource(ctx, t, tenant)
 
-	defaults := bat.DefaultResources{
+	requirements := bat.WorkloadRequirements{
 		VCPUs: 2,
 		MemMB: 128,
 	}
@@ -196,11 +196,11 @@ func TestCreateWorkloadWithSizedVolume(t *testing.T) {
 	}
 
 	opt := bat.WorkloadOptions{
-		Description: "BAT VM Test",
-		VMType:      "qemu",
-		FWType:      "legacy",
-		Defaults:    defaults,
-		Disks:       []bat.Disk{disk},
+		Description:  "BAT VM Test",
+		VMType:       "qemu",
+		FWType:       "legacy",
+		Requirements: requirements,
+		Disks:        []bat.Disk{disk},
 	}
 
 	workloadID, err := bat.CreateWorkload(ctx, tenant, opt, vmCloudInit)

--- a/bat/workload.go
+++ b/bat/workload.go
@@ -50,21 +50,21 @@ type Disk struct {
 	Ephemeral bool    `yaml:"ephemeral"`
 }
 
-// DefaultResources indicate how many cpus and mem to allocate.
-type DefaultResources struct {
+// WorkloadRequirements indicate how many cpus and mem to allocate.
+type WorkloadRequirements struct {
 	VCPUs int `yaml:"vcpus"`
 	MemMB int `yaml:"mem_mb"`
 }
 
 // WorkloadOptions is used to generate a workload definition in yaml.
 type WorkloadOptions struct {
-	Description     string           `yaml:"description"`
-	VMType          string           `yaml:"vm_type"`
-	FWType          string           `yaml:"fw_type"`
-	ImageName       string           `yaml:"image_name"`
-	Defaults        DefaultResources `yaml:"defaults"`
-	CloudConfigFile string           `yaml:"cloud_init"`
-	Disks           []Disk           `yaml:"disks"`
+	Description     string               `yaml:"description"`
+	VMType          string               `yaml:"vm_type"`
+	FWType          string               `yaml:"fw_type"`
+	ImageName       string               `yaml:"image_name"`
+	Requirements    WorkloadRequirements `yaml:"requirements"`
+	CloudConfigFile string               `yaml:"cloud_init"`
+	Disks           []Disk               `yaml:"disks"`
 }
 
 // this function should output the yaml file for the workload definition

--- a/ciao-cli/examples/fedora_cloud.yaml
+++ b/ciao-cli/examples/fedora_cloud.yaml
@@ -1,7 +1,7 @@
 description: "Fedora VM no storage"
 vm_type: qemu
 fw_type: legacy
-defaults:
+requirements:
     vcpus: 2
     mem_mb: 512
 cloud_init: fedora_vm.yaml

--- a/ciao-cli/examples/fedora_cloud_disk.yaml
+++ b/ciao-cli/examples/fedora_cloud_disk.yaml
@@ -1,7 +1,7 @@
 description: "Fedora VM with attached empty storage"
 vm_type: qemu
 fw_type: legacy
-defaults:
+requirements:
     vcpus: 2
     mem_mb: 512
 cloud_init: "fedora_vm.yaml"

--- a/ciao-cli/examples/ubuntu_latest.yaml
+++ b/ciao-cli/examples/ubuntu_latest.yaml
@@ -1,7 +1,7 @@
 description: "Ubuntu latest container"
 vm_type: docker
 image_name: "ubuntu:latest"
-defaults:
+requirements:
   vcpus: 2
   mem_mb: 512
 cloud_init: "docker-ubuntu.yaml"

--- a/ciao-cli/workload.go
+++ b/ciao-cli/workload.go
@@ -82,20 +82,13 @@ func (cmd *workloadListCommand) run(args []string) error {
 	}
 
 	var workloads []Workload
-	for i, wl := range wls {
+	for _, wl := range wls {
 		workloads = append(workloads, Workload{
 			Name: wl.Description,
 			ID:   wl.ID,
+			Mem:  wl.Requirements.MemMB,
+			CPUs: wl.Requirements.VCPUs,
 		})
-
-		for _, r := range wl.Defaults {
-			if r.Type == payloads.MemMB {
-				workloads[i].Mem = r.Value
-			}
-			if r.Type == payloads.VCPUs {
-				workloads[i].CPUs = r.Value
-			}
-		}
 	}
 
 	if cmd.template != "" {
@@ -240,20 +233,8 @@ func optToReq(opt workloadOptions, req *types.Workload) error {
 		return err
 	}
 
-	// all default resources are required.
-	defaults := opt.Defaults
-
-	r := payloads.RequestedResource{
-		Type:  payloads.VCPUs,
-		Value: defaults.VCPUs,
-	}
-	req.Defaults = append(req.Defaults, r)
-
-	r = payloads.RequestedResource{
-		Type:  payloads.MemMB,
-		Value: defaults.MemMB,
-	}
-	req.Defaults = append(req.Defaults, r)
+	req.Requirements.MemMB = opt.Defaults.MemMB
+	req.Requirements.VCPUs = opt.Defaults.VCPUs
 
 	return nil
 }
@@ -265,13 +246,8 @@ func outputWorkload(w types.Workload) {
 	opt.VMType = string(w.VMType)
 	opt.FWType = w.FWType
 	opt.ImageName = w.ImageName
-	for _, d := range w.Defaults {
-		if d.Type == payloads.VCPUs {
-			opt.Defaults.VCPUs = d.Value
-		} else if d.Type == payloads.MemMB {
-			opt.Defaults.MemMB = d.Value
-		}
-	}
+	opt.Defaults.MemMB = w.Requirements.MemMB
+	opt.Defaults.VCPUs = w.Requirements.VCPUs
 
 	for _, s := range w.Storage {
 		d := disk{

--- a/ciao-cli/workload.go
+++ b/ciao-cli/workload.go
@@ -142,7 +142,7 @@ type disk struct {
 	Ephemeral bool    `yaml:"ephemeral"`
 }
 
-type defaultResources struct {
+type workloadRequirements struct {
 	VCPUs int `yaml:"vcpus"`
 	MemMB int `yaml:"mem_mb"`
 }
@@ -150,13 +150,13 @@ type defaultResources struct {
 // we currently only use the first disk due to lack of support
 // in types.Workload for multiple storage resources.
 type workloadOptions struct {
-	Description     string           `yaml:"description"`
-	VMType          string           `yaml:"vm_type"`
-	FWType          string           `yaml:"fw_type,omitempty"`
-	ImageName       string           `yaml:"image_name,omitempty"`
-	Defaults        defaultResources `yaml:"defaults"`
-	CloudConfigFile string           `yaml:"cloud_init,omitempty"`
-	Disks           []disk           `yaml:"disks,omitempty"`
+	Description     string               `yaml:"description"`
+	VMType          string               `yaml:"vm_type"`
+	FWType          string               `yaml:"fw_type,omitempty"`
+	ImageName       string               `yaml:"image_name,omitempty"`
+	Requirements    workloadRequirements `yaml:"requirements"`
+	CloudConfigFile string               `yaml:"cloud_init,omitempty"`
+	Disks           []disk               `yaml:"disks,omitempty"`
 }
 
 func optToReqStorage(opt workloadOptions) ([]types.StorageResource, error) {
@@ -233,8 +233,8 @@ func optToReq(opt workloadOptions, req *types.Workload) error {
 		return err
 	}
 
-	req.Requirements.MemMB = opt.Defaults.MemMB
-	req.Requirements.VCPUs = opt.Defaults.VCPUs
+	req.Requirements.MemMB = opt.Requirements.MemMB
+	req.Requirements.VCPUs = opt.Requirements.VCPUs
 
 	return nil
 }
@@ -246,8 +246,8 @@ func outputWorkload(w types.Workload) {
 	opt.VMType = string(w.VMType)
 	opt.FWType = w.FWType
 	opt.ImageName = w.ImageName
-	opt.Defaults.MemMB = w.Requirements.MemMB
-	opt.Defaults.VCPUs = w.Requirements.VCPUs
+	opt.Requirements.MemMB = w.Requirements.MemMB
+	opt.Requirements.VCPUs = w.Requirements.VCPUs
 
 	for _, s := range w.Storage {
 		d := disk{

--- a/ciao-controller/api/api_test.go
+++ b/ciao-controller/api/api_test.go
@@ -130,10 +130,10 @@ var tests = []test{
 	{
 		"POST",
 		"/workloads",
-		`{"id":"","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_name":"","config":"this will totally work!","defaults":[]}`,
+		`{"id":"","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_name":"","config":"this will totally work!"}`,
 		fmt.Sprintf("application/%s", WorkloadsV1),
 		http.StatusCreated,
-		`{"workload":{"id":"ba58f471-0735-4773-9550-188e2d012941","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_name":"","config":"this will totally work!","defaults":[],"storage":null,"visibility":"public"},"link":{"rel":"self","href":"/workloads/ba58f471-0735-4773-9550-188e2d012941"}}`,
+		`{"workload":{"id":"ba58f471-0735-4773-9550-188e2d012941","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_name":"","config":"this will totally work!","storage":null,"visibility":"public","workload_requirements":{"MemMB":0,"VCPUs":0,"NetworkNode":false}},"link":{"rel":"self","href":"/workloads/ba58f471-0735-4773-9550-188e2d012941"}}`,
 	},
 	{
 		"DELETE",
@@ -149,7 +149,7 @@ var tests = []test{
 		"",
 		fmt.Sprintf("application/%s", WorkloadsV1),
 		http.StatusOK,
-		`{"id":"ba58f471-0735-4773-9550-188e2d012941","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_name":"","config":"this will totally work!","defaults":null,"storage":null,"visibility":"private"}`,
+		`{"id":"ba58f471-0735-4773-9550-188e2d012941","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_name":"","config":"this will totally work!","storage":null,"visibility":"private","workload_requirements":{"MemMB":0,"VCPUs":0,"NetworkNode":false}}`,
 	},
 	{
 		"GET",
@@ -157,7 +157,7 @@ var tests = []test{
 		"",
 		fmt.Sprintf("application/%s", WorkloadsV1),
 		http.StatusOK,
-		`[{"id":"ba58f471-0735-4773-9550-188e2d012941","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_name":"","config":"this will totally work!","defaults":null,"storage":null,"visibility":"private"}]`,
+		`[{"id":"ba58f471-0735-4773-9550-188e2d012941","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_name":"","config":"this will totally work!","storage":null,"visibility":"private","workload_requirements":{"MemMB":0,"VCPUs":0,"NetworkNode":false}}]`,
 	},
 	{
 		"GET",

--- a/ciao-controller/client.go
+++ b/ciao-controller/client.go
@@ -109,8 +109,10 @@ func (client *ssntpClient) releaseResources(instanceID string) error {
 		return errors.Wrapf(err, "error getting workload for instance from datastore")
 	}
 
-	resources := []payloads.RequestedResource{{Type: payloads.Instance, Value: 1}}
-	resources = append(resources, wl.Defaults...)
+	resources := []payloads.RequestedResource{
+		{Type: payloads.Instance, Value: 1},
+		{Type: payloads.MemMB, Value: wl.Requirements.MemMB},
+		{Type: payloads.VCPUs, Value: wl.Requirements.VCPUs}}
 	client.ctl.qs.Release(i.TenantID, resources...)
 	return nil
 }
@@ -584,7 +586,7 @@ func (client *ssntpClient) RestartInstance(i *types.Instance, w *types.Workload,
 		FWType:              payloads.Firmware(w.FWType),
 		VMType:              w.VMType,
 		InstancePersistence: payloads.Host,
-		Requirements:        workloadDefaultsToRequirements(w),
+		Requirements:        w.Requirements,
 		Networking: payloads.NetworkResources{
 			VnicMAC:  i.MACAddress,
 			VnicUUID: i.VnicUUID,

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -55,17 +55,6 @@ users:
     - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDerQfD+qkb0V0XdQs8SBWqy4sQmqYFP96n/kI4Cq162w4UE8pTxy0ozAPldOvBJjljMvgaNKSAddknkhGcrNUvvJsUcZFm2qkafi32WyBdGFvIc45A+8O7vsxPXgHEsS9E3ylEALXAC3D0eX7pPtRiAbasLlY+VcACRqr3bPDSZTfpCmIkV2334uZD9iwOvTVeR+FjGDqsfju4DyzoAIqpPasE0+wk4Vbog7osP+qvn1gj5kQyusmr62+t0wx+bs2dF5QemksnFOswUrv9PGLhZgSMmDQrRYuvEfIAC7IdN/hfjTn0OokzljBiuWQ4WIIba/7xTYLVujJV65qH3heaSMxJJD7eH9QZs9RdbbdTXMFuJFsHV2OF6wZRp18tTNZZJMqiHZZSndC5WP1WrUo3Au/9a+ighSaOiVddHsPG07C/TOEnr3IrwU7c9yIHeeRFHmcQs9K0+n9XtrmrQxDQ9/mLkfje80Ko25VJ/QpAQPzCKh2KfQ4RD+/PxBUScx/lHIHOIhTSCh57ic629zWgk0coSQDi4MKSa5guDr3cuDvt4RihGviDM6V68ewsl0gh6Z9c0Hw7hU0vky4oxak5AiySiPz0FtsOnAzIL0UON+yMuKzrJgLjTKodwLQ0wlBXu43cD+P8VXwQYeqNSzfrhBnHqsrMf4lTLtc7kDDTcw== ciao@ciao
 ...
 	`
-	cpus := payloads.RequestedResource{
-		Type:      payloads.VCPUs,
-		Value:     2,
-		Mandatory: false,
-	}
-
-	mem := payloads.RequestedResource{
-		Type:      payloads.MemMB,
-		Value:     512,
-		Mandatory: false,
-	}
 
 	wl := types.Workload{
 		ID:          uuid.Generate().String(),
@@ -75,8 +64,11 @@ users:
 		VMType:      payloads.QEMU,
 		ImageName:   "",
 		Config:      testConfig,
-		Defaults:    []payloads.RequestedResource{cpus, mem},
-		Storage:     nil,
+		Requirements: payloads.WorkloadRequirements{
+			VCPUs: 2,
+			MemMB: 512,
+		},
+		Storage: nil,
 	}
 
 	return ctl.ds.AddWorkload(wl)

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -2512,23 +2512,6 @@ users:
     - ` + key + `
 ...
 `
-	cpus := payloads.RequestedResource{
-		Type:      payloads.VCPUs,
-		Value:     vcpus,
-		Mandatory: false,
-	}
-
-	mem := payloads.RequestedResource{
-		Type:      payloads.MemMB,
-		Value:     memMB,
-		Mandatory: false,
-	}
-
-	network := payloads.RequestedResource{
-		Type:      payloads.NetworkNode,
-		Value:     1,
-		Mandatory: true,
-	}
 
 	storage := types.StorageResource{
 		ID:         "",
@@ -2545,9 +2528,13 @@ users:
 		FWType:      string(payloads.EFI),
 		VMType:      payloads.QEMU,
 		Config:      config,
-		Defaults:    []payloads.RequestedResource{cpus, mem, network},
-		Storage:     []types.StorageResource{storage},
-		Visibility:  types.Internal,
+		Requirements: payloads.WorkloadRequirements{
+			VCPUs:       vcpus,
+			MemMB:       memMB,
+			NetworkNode: true,
+		},
+		Storage:    []types.StorageResource{storage},
+		Visibility: types.Internal,
 	}
 
 	// for now we have a single global cnci workload.

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -54,13 +54,6 @@ func addInstance(tenant *types.Tenant, workload types.Workload, name string) (in
 		Mask: mask,
 	}
 
-	resources := make(map[string]int)
-	rr := workload.Defaults
-
-	for i := range rr {
-		resources[string(rr[i].Type)] = rr[i].Value
-	}
-
 	instance = &types.Instance{
 		TenantID:   tenant.ID,
 		WorkloadID: workload.ID,
@@ -111,17 +104,6 @@ users:
     - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDerQfD+qkb0V0XdQs8SBWqy4sQmqYFP96n/kI4Cq162w4UE8pTxy0ozAPldOvBJjljMvgaNKSAddknkhGcrNUvvJsUcZFm2qkafi32WyBdGFvIc45A+8O7vsxPXgHEsS9E3ylEALXAC3D0eX7pPtRiAbasLlY+VcACRqr3bPDSZTfpCmIkV2334uZD9iwOvTVeR+FjGDqsfju4DyzoAIqpPasE0+wk4Vbog7osP+qvn1gj5kQyusmr62+t0wx+bs2dF5QemksnFOswUrv9PGLhZgSMmDQrRYuvEfIAC7IdN/hfjTn0OokzljBiuWQ4WIIba/7xTYLVujJV65qH3heaSMxJJD7eH9QZs9RdbbdTXMFuJFsHV2OF6wZRp18tTNZZJMqiHZZSndC5WP1WrUo3Au/9a+ighSaOiVddHsPG07C/TOEnr3IrwU7c9yIHeeRFHmcQs9K0+n9XtrmrQxDQ9/mLkfje80Ko25VJ/QpAQPzCKh2KfQ4RD+/PxBUScx/lHIHOIhTSCh57ic629zWgk0coSQDi4MKSa5guDr3cuDvt4RihGviDM6V68ewsl0gh6Z9c0Hw7hU0vky4oxak5AiySiPz0FtsOnAzIL0UON+yMuKzrJgLjTKodwLQ0wlBXu43cD+P8VXwQYeqNSzfrhBnHqsrMf4lTLtc7kDDTcw== ciao@ciao
 ...
 	`
-	cpus := payloads.RequestedResource{
-		Type:      payloads.VCPUs,
-		Value:     2,
-		Mandatory: false,
-	}
-
-	mem := payloads.RequestedResource{
-		Type:      payloads.MemMB,
-		Value:     512,
-		Mandatory: false,
-	}
 
 	storage := types.StorageResource{
 		ID:        "",
@@ -137,8 +119,11 @@ users:
 		VMType:      payloads.QEMU,
 		ImageName:   "",
 		Config:      testConfig,
-		Defaults:    []payloads.RequestedResource{cpus, mem},
-		Storage:     []types.StorageResource{storage},
+		Requirements: payloads.WorkloadRequirements{
+			VCPUs: 2,
+			MemMB: 512,
+		},
+		Storage: []types.StorageResource{storage},
 	}
 
 	return ds.AddWorkload(wl)

--- a/ciao-controller/internal/datastore/sqlite3db_test.go
+++ b/ciao-controller/internal/datastore/sqlite3db_test.go
@@ -942,17 +942,6 @@ users:
     - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDerQfD+qkb0V0XdQs8SBWqy4sQmqYFP96n/kI4Cq162w4UE8pTxy0ozAPldOvBJjljMvgaNKSAddknkhGcrNUvvJsUcZFm2qkafi32WyBdGFvIc45A+8O7vsxPXgHEsS9E3ylEALXAC3D0eX7pPtRiAbasLlY+VcACRqr3bPDSZTfpCmIkV2334uZD9iwOvTVeR+FjGDqsfju4DyzoAIqpPasE0+wk4Vbog7osP+qvn1gj5kQyusmr62+t0wx+bs2dF5QemksnFOswUrv9PGLhZgSMmDQrRYuvEfIAC7IdN/hfjTn0OokzljBiuWQ4WIIba/7xTYLVujJV65qH3heaSMxJJD7eH9QZs9RdbbdTXMFuJFsHV2OF6wZRp18tTNZZJMqiHZZSndC5WP1WrUo3Au/9a+ighSaOiVddHsPG07C/TOEnr3IrwU7c9yIHeeRFHmcQs9K0+n9XtrmrQxDQ9/mLkfje80Ko25VJ/QpAQPzCKh2KfQ4RD+/PxBUScx/lHIHOIhTSCh57ic629zWgk0coSQDi4MKSa5guDr3cuDvt4RihGviDM6V68ewsl0gh6Z9c0Hw7hU0vky4oxak5AiySiPz0FtsOnAzIL0UON+yMuKzrJgLjTKodwLQ0wlBXu43cD+P8VXwQYeqNSzfrhBnHqsrMf4lTLtc7kDDTcw== ciao@ciao
 ...
 	`
-	cpus := payloads.RequestedResource{
-		Type:      payloads.VCPUs,
-		Value:     2,
-		Mandatory: false,
-	}
-
-	mem := payloads.RequestedResource{
-		Type:      payloads.MemMB,
-		Value:     512,
-		Mandatory: false,
-	}
 
 	storage := types.StorageResource{
 		ID:        "",
@@ -968,8 +957,11 @@ users:
 		VMType:      payloads.QEMU,
 		ImageName:   "",
 		Config:      testConfig,
-		Defaults:    []payloads.RequestedResource{mem, cpus},
-		Storage:     []types.StorageResource{storage},
+		Requirements: payloads.WorkloadRequirements{
+			VCPUs: 2,
+			MemMB: 512,
+		},
+		Storage: []types.StorageResource{storage},
 	}
 
 	// file will be added, so we will want to remove it.

--- a/ciao-controller/quotas.go
+++ b/ciao-controller/quotas.go
@@ -79,8 +79,10 @@ func populateQuotasFromDatastore(qs *quotas.Quotas, ds *datastore.Datastore) err
 			if err != nil {
 				return errors.Wrapf(err, "error getting workload")
 			}
-			resources := []payloads.RequestedResource{{Type: payloads.Instance, Value: 1}}
-			resources = append(resources, wl.Defaults...)
+			resources := []payloads.RequestedResource{
+				{Type: payloads.Instance, Value: 1},
+				{Type: payloads.MemMB, Value: wl.Requirements.MemMB},
+				{Type: payloads.VCPUs, Value: wl.Requirements.VCPUs}}
 			<-qs.Consume(t.ID, resources...)
 		}
 	}

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -80,16 +80,16 @@ type StorageResource struct {
 // Workload contains resource and configuration information for a user
 // workload.
 type Workload struct {
-	ID          string                       `json:"id"`
-	TenantID    string                       `json:"-"`
-	Description string                       `json:"description"`
-	FWType      string                       `json:"fw_type"`
-	VMType      payloads.Hypervisor          `json:"vm_type"`
-	ImageName   string                       `json:"image_name"`
-	Config      string                       `json:"config"`
-	Defaults    []payloads.RequestedResource `json:"defaults"`
-	Storage     []StorageResource            `json:"storage"`
-	Visibility  Visibility                   `json:"visibility"`
+	ID           string                        `json:"id"`
+	TenantID     string                        `json:"-"`
+	Description  string                        `json:"description"`
+	FWType       string                        `json:"fw_type"`
+	VMType       payloads.Hypervisor           `json:"vm_type"`
+	ImageName    string                        `json:"image_name"`
+	Config       string                        `json:"config"`
+	Storage      []StorageResource             `json:"storage"`
+	Visibility   Visibility                    `json:"visibility"`
+	Requirements payloads.WorkloadRequirements `json:"workload_requirements"`
 }
 
 // WorkloadResponse will be returned from /workloads apis

--- a/ciao-deploy/deploy/workloads.go
+++ b/ciao-deploy/deploy/workloads.go
@@ -92,7 +92,7 @@ var images = []workloadDetails{
 			Description: "Fedora test VM",
 			VMType:      "qemu",
 			FWType:      "legacy",
-			Defaults: bat.DefaultResources{
+			Requirements: bat.WorkloadRequirements{
 				VCPUs: 2,
 				MemMB: 128,
 			},
@@ -107,7 +107,7 @@ var images = []workloadDetails{
 			Description: "Ubuntu test VM",
 			VMType:      "qemu",
 			FWType:      "legacy",
-			Defaults: bat.DefaultResources{
+			Requirements: bat.WorkloadRequirements{
 				VCPUs: 2,
 				MemMB: 256,
 			},
@@ -121,7 +121,7 @@ var images = []workloadDetails{
 				Description: "Clear Linux test VM",
 				VMType:      "qemu",
 				FWType:      "efi",
-				Defaults: bat.DefaultResources{
+				Requirements: bat.WorkloadRequirements{
 					VCPUs: 2,
 					MemMB: 128,
 				},
@@ -134,7 +134,7 @@ var images = []workloadDetails{
 			Description: "Debian latest test container",
 			VMType:      "docker",
 			ImageName:   "debian:latest",
-			Defaults: bat.DefaultResources{
+			Requirements: bat.WorkloadRequirements{
 				VCPUs: 2,
 				MemMB: 128,
 			},
@@ -146,7 +146,7 @@ var images = []workloadDetails{
 			Description: "Ubuntu latest test container",
 			VMType:      "docker",
 			ImageName:   "ubuntu:latest",
-			Defaults: bat.DefaultResources{
+			Requirements: bat.WorkloadRequirements{
 				VCPUs: 2,
 				MemMB: 128,
 			},

--- a/k8s/kubicle/cloudinit.go
+++ b/k8s/kubicle/cloudinit.go
@@ -19,7 +19,7 @@ package main
 const workloadTemplate = `description: "{{.Description}}"
 vm_type: qemu
 fw_type: legacy
-defaults:
+requirements:
     vcpus: {{.VCPUs}}
     mem_mb: {{.RAMMiB}}
 cloud_init: "{{.UserDataFile}}"


### PR DESCRIPTION
Replace the concept of workload defaults with workload requirements in the user experience and in the database store. This opens up the opportunity for extending workload requirements beyond the current CPU and memory needs to include further workload routing such as node id and hostname and capabilities such as CPU features.