### PR TITLE
ciao-{controller,launcher,scheduler}: log panics to glog

### DIFF
--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"sync"
 	"syscall"
 
@@ -118,6 +119,13 @@ func getNameFromCert(httpsCAcert, httpsKey string) (string, error) {
 }
 
 func main() {
+	defer func() {
+		if r := recover(); r != nil {
+			glog.Errorf("%s", debug.Stack())
+			glog.Flush()
+		}
+	}()
+
 	var wg sync.WaitGroup
 	var err error
 

--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -522,6 +522,12 @@ DONE:
 }
 
 func main() {
+	defer func() {
+		if r := recover(); r != nil {
+			glog.Errorf("%s", debug.Stack())
+			glog.Flush()
+		}
+	}()
 
 	flag.Parse()
 

--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime/debug"
 	"runtime/pprof"
 	"sync"
 	"syscall"
@@ -1232,6 +1233,13 @@ func configSchedulerServer() (sched *ssntpSchedulerServer) {
 }
 
 func main() {
+	defer func() {
+		if r := recover(); r != nil {
+			glog.Errorf("%s", debug.Stack())
+			glog.Flush()
+		}
+	}()
+
 	flag.Parse()
 
 	if err := initLogger(); err != nil {


### PR DESCRIPTION
If our daemons panic we should capture the panic backtrace and send it
to glog. It is important to flush glog otherwise the output may not get
written to the files.

Fixes: #1571

Signed-off-by: Rob Bradford <robert.bradford@intel.com>