### PR TITLE
Reduce capabilities of ciao services and their children

### DIFF
--- a/ciao-deploy/cmd/setup.go
+++ b/ciao-deploy/cmd/setup.go
@@ -33,7 +33,7 @@ func setup() int {
 	ctx, cancelFunc := getSignalContext()
 	defer cancelFunc()
 
-	err := deploy.SetupMaster(ctx, force, imageCacheDirectory, clusterConf)
+	err := deploy.SetupMaster(ctx, force, imageCacheDirectory, clusterConf, localLauncher)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error provisioning system as master: %v\n", err)
 		return 1

--- a/ciao-deploy/deploy/nodes.go
+++ b/ciao-deploy/deploy/nodes.go
@@ -152,7 +152,8 @@ func createRemoteCiaoDirectory(ctx context.Context, hostname, sshUser, path stri
 }
 
 func setupNode(ctx context.Context, anchorCertPath string, caCertPath string, hostname string, sshUser string, networkNode bool) (errOut error) {
-	err := SSHRunCommand(ctx, sshUser, hostname, fmt.Sprintf("sudo useradd -r %s -G docker,kvm", ciaoUser))
+	err := SSHRunCommand(ctx, sshUser, hostname,
+		fmt.Sprintf("sudo useradd -r %s -G docker,kvm -d %s -s /bin/false", ciaoUser, ciaoDataDir))
 	if err != nil {
 		return errors.Wrapf(err, "Error creating %s user", ciaoUser)
 	}

--- a/ciao-deploy/deploy/nodes.go
+++ b/ciao-deploy/deploy/nodes.go
@@ -259,6 +259,9 @@ func setupNode(ctx context.Context, anchorCertPath string, caCertPath string, ho
 		Caps: []string{"CAP_NET_ADMIN", "CAP_NET_RAW", "CAP_DAC_OVERRIDE",
 			"CAP_SETGID", "CAP_SETUID", "CAP_SYS_PTRACE", "CAP_SYS_MODULE"},
 		Roles: roles,
+		Deps: []string{
+			"docker.service",
+		},
 	})
 	if err != nil {
 		return errors.Wrap(err, "Error installing tool on node")

--- a/ciao-deploy/deploy/nodes.go
+++ b/ciao-deploy/deploy/nodes.go
@@ -196,7 +196,7 @@ func createRemoteCiaoDirectory(ctx context.Context, hostname, sshUser, path stri
 }
 
 func setupNode(ctx context.Context, anchorCertPath string, caCertPath string, hostname string, sshUser string, networkNode bool) (errOut error) {
-	err, status := SSHRunCommandWithStatus(ctx, sshUser, hostname,
+	status, err := SSHRunCommandWithStatus(ctx, sshUser, hostname,
 		fmt.Sprintf("sudo useradd -r %s -G docker,kvm -d %s -s /bin/false", ciaoUser, ciaoDataDir))
 	if err != nil {
 		if status != userAlreadyExistsStatus {

--- a/ciao-deploy/deploy/nodes.go
+++ b/ciao-deploy/deploy/nodes.go
@@ -209,7 +209,8 @@ func setupNode(ctx context.Context, anchorCertPath string, caCertPath string, ho
 		User:       ciaoUser,
 		CertPath:   remoteCertPath,
 		CACertPath: caCertPath,
-		Caps:       []string{"CAP_NET_ADMIN", "CAP_NET_RAW", "CAP_DAC_OVERRIDE", "CAP_SYS_MODULE"},
+		Caps: []string{"CAP_NET_ADMIN", "CAP_NET_RAW", "CAP_DAC_OVERRIDE",
+			"CAP_SETGID", "CAP_SETUID", "CAP_SYS_PTRACE", "CAP_SYS_MODULE"},
 	})
 	if err != nil {
 		return errors.Wrap(err, "Error installing tool on node")

--- a/ciao-deploy/deploy/setup.go
+++ b/ciao-deploy/deploy/setup.go
@@ -381,7 +381,8 @@ func createCiaoDirectory(ctx context.Context, path string) error {
 }
 
 func createUserAndDirs(ctx context.Context) (func(), error) {
-	cmd := exec.CommandContext(ctx, "sudo", "useradd", "-r", ciaoUser, "-G", "docker,kvm")
+	cmd := exec.CommandContext(ctx, "sudo", "useradd", "-r", ciaoUser, "-G",
+		"docker,kvm", "-d", ciaoDataDir, "-s", "/bin/false")
 	if err := cmd.Run(); err != nil {
 		return nil, errors.Wrapf(err, "Error running: %v", cmd.Args)
 	}

--- a/ciao-deploy/deploy/setup.go
+++ b/ciao-deploy/deploy/setup.go
@@ -58,6 +58,7 @@ type unitFileConf struct {
 	CertPath   string
 	Caps       []string
 	Roles      []string
+	Deps       []string
 }
 
 var ciaoLockDir = "/tmp/lock/ciao"
@@ -219,6 +220,7 @@ func createSchedulerCerts(ctx context.Context, force bool, serverIP string) (str
 var systemdServiceData = `[Unit]
 Description={{.Tool}} service
 Wants={{.Tool}}-prepare.service
+{{range .Deps}}Wants={{.}}{{println}}{{end}}
 After={{.Tool}}-prepare.service
 
 [Service]

--- a/ciao-deploy/deploy/setup.go
+++ b/ciao-deploy/deploy/setup.go
@@ -98,6 +98,7 @@ func createConfigurationFile(ctx context.Context, clusterConf *ClusterConfigurat
 	// See issue #1541
 	config.Configure.Launcher.DiskLimit = false
 	config.Configure.Launcher.MemoryLimit = !clusterConf.DisableLimits
+	config.Configure.Launcher.ChildUser = ciaoUser
 
 	data, err := yaml.Marshal(config)
 	if err != nil {

--- a/ciao-deploy/deploy/setup.go
+++ b/ciao-deploy/deploy/setup.go
@@ -320,7 +320,11 @@ func InstallTool(ctx context.Context, config unitFileConf) (errOut error) {
 
 	toolPath := InGoPath(path.Join("/bin", config.Tool))
 
-	systemToolPath := path.Join("/usr/local/bin/", config.Tool)
+	installDir := "/usr/local/bin"
+	systemToolPath := path.Join(installDir, config.Tool)
+	if err := SudoMakeDirectory(ctx, installDir); err != nil {
+		return errors.Wrapf(err, "Error creating %s", installDir)
+	}
 	if err := SudoCopyFile(ctx, systemToolPath, toolPath); err != nil {
 		return errors.Wrap(err, "Error copying tool to destination")
 	}
@@ -680,6 +684,9 @@ func installLocalLauncher(ctx context.Context, launcherCertPath string, caCertPa
 		},
 		Roles: []string{
 			"agent", "net-agent",
+		},
+		Deps: []string{
+			"docker.service",
 		},
 	})
 	return errors.Wrap(err, "Error installing launcher")

--- a/ciao-deploy/deploy/utils.go
+++ b/ciao-deploy/deploy/utils.go
@@ -153,6 +153,15 @@ func SudoRemoveFile(ctx context.Context, dest string) error {
 	return nil
 }
 
+// SudoChownFiles changes the user and group one or more files to ciaoUserAndGroup
+func SudoChownFiles(ctx context.Context, dest ...string) error {
+	cmd := SudoCommandContext(ctx, "chown", append([]string{ciaoUserAndGroup}, dest...)...)
+	if err := cmd.Run(); err != nil {
+		return errors.Wrapf(err, "Error running: %v", cmd.Args)
+	}
+	return nil
+}
+
 // InGoPath returns the desired path relative to $GOPATH
 func InGoPath(path string) string {
 	data, err := exec.Command("go", "env", "GOPATH").Output()

--- a/ciao-deploy/deploy/utils.go
+++ b/ciao-deploy/deploy/utils.go
@@ -302,19 +302,19 @@ func SSHRunCommand(ctx context.Context, user string, host string, command string
 
 // SSHRunCommandWithStatus is a convenience function to run a command on a given host.
 // This assumes the key is already in the keyring for the provided user. On success,
-// the function returns nil, 0.  On failure, the function returns an error and if
-// the cause of the error was due to an exit error on the remote node, and an integer
-// containing the exit code.  If the code is -1, the exit code was not available.
-func SSHRunCommandWithStatus(ctx context.Context, user string, host string, command string) (error, int) {
+// the function returns 0, nil.  On failure, the function returns an integer indicating
+// the exit code of the command and an error.  The exit code is set to -1, if the exit
+// code was not available.
+func SSHRunCommandWithStatus(ctx context.Context, user string, host string, command string) (int, error) {
 	status := -1
 	err := SSHRunCommand(ctx, user, host, command)
 	if err == nil {
-		return nil, 0
+		return 0, nil
 	}
 	if err, ok := errors.Cause(err).(*ssh.ExitError); ok {
 		status = err.ExitStatus()
 	}
-	return err, status
+	return status, err
 }
 
 // SSHCreateFile creates a file on a remote machine

--- a/ciao-deploy/deploy/utils.go
+++ b/ciao-deploy/deploy/utils.go
@@ -302,6 +302,11 @@ func SSHRunCommand(ctx context.Context, user string, host string, command string
 
 // SSHCreateFile creates a file on a remote machine
 func SSHCreateFile(ctx context.Context, user string, host string, dest string, f io.Reader) error {
+	err := SSHRunCommand(ctx, user, host, fmt.Sprintf("sudo mkdir -p %s", filepath.Dir(dest)))
+	if err != nil {
+		return errors.Wrapf(err, "Error creating %s", filepath.Dir(dest))
+	}
+
 	client, err := sshClient(ctx, user, host)
 	if err != nil {
 		return errors.Wrap(err, "Error creating client")

--- a/ciao-deploy/scripts/cleanup.sh
+++ b/ciao-deploy/scripts/cleanup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+sudo systemctl disable ciao-controller
+sudo systemctl disable ciao-scheduler
+sudo systemctl stop ciao-controller
+sudo systemctl stop ciao-scheduler
+sudo rm /etc/systemd/system/ciao*
+sudo rbd ls -l | cut -f 1 -d " " | grep ciao-image | xargs -n 1 sudo rbd snap unprotect  -f
+sudo rbd ls | xargs -n 1 sudo rbd snap purge
+sudo rbd ls | xargs -n 1 sudo rbd rm
+sudo rm -rf /var/lib/ciao/data/
+sudo rm -f /usr/local/bin/ciao*
+sudo rm -rf /etc/ciao
+sudo rm /etc/pki/ciao/cert-*.pem
+sudo rm /etc/pki/ciao/CAcert.pem

--- a/ciao-launcher/README.md
+++ b/ciao-launcher/README.md
@@ -105,8 +105,12 @@ Usage of ciao-launcher:
         log to standard error instead of files
   -network
         Enable networking (default true)
+  -osprepare
+        Install dependencies
   -qemu-virtualisation value
         QEMU virtualisation method. Can be 'kvm', 'auto' or 'software' (default kvm)
+  -roles string
+        Roles for which dependencies are to be installed (default "agent")
   -simulation
         Launcher simulation
   -stderrthreshold value

--- a/ciao-launcher/docker.go
+++ b/ciao-launcher/docker.go
@@ -373,7 +373,7 @@ func (d *docker) deleteImage() error {
 	return dockerDeleteContainer(d.cli, d.dockerID, d.cfg.Instance)
 }
 
-func (d *docker) startVM(vnicName, ipAddress, cephID string) error {
+func (d *docker) startVM(vnicName, ipAddress, cephID string, fds []*os.File) error {
 	err := d.initDockerClient()
 	if err != nil {
 		return err

--- a/ciao-launcher/instance_test.go
+++ b/ciao-launcher/instance_test.go
@@ -91,7 +91,7 @@ func (v *instanceTestState) deleteImage() error {
 	return nil
 }
 
-func (v *instanceTestState) startVM(vnicName, ipAddress, cephID string) error {
+func (v *instanceTestState) startVM(vnicName, ipAddress, cephID string, fds []*os.File) error {
 	if v.failStartVM {
 		return fmt.Errorf("Failed to start VM")
 	}

--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -87,6 +87,7 @@ var memLimit bool
 var cephID string
 var simulate bool
 var childProcessCreds *syscall.SysProcAttr
+var childProcessKVMCreds *syscall.SysProcAttr
 var maxInstances = int(math.MaxInt32)
 
 func init() {
@@ -313,6 +314,30 @@ func loadClusterConfig(conn serverConn) error {
 			Credential: &syscall.Credential{
 				Uid: uint32(uid),
 				Gid: uint32(gid),
+			},
+		}
+		grp, err = user.LookupGroup("kvm")
+		if err != nil {
+			return err
+		}
+		kgid, err := strconv.Atoi(grp.Gid)
+		if err != nil {
+			return err
+		}
+		grp, err = user.LookupGroup("disk")
+		if err != nil {
+			return err
+		}
+		dgid, err := strconv.Atoi(grp.Gid)
+		if err != nil {
+			return err
+		}
+
+		childProcessKVMCreds = &syscall.SysProcAttr{
+			Credential: &syscall.Credential{
+				Uid:    uint32(uid),
+				Gid:    uint32(gid),
+				Groups: []uint32{uint32(kgid), uint32(dgid)},
 			},
 		}
 	}

--- a/ciao-launcher/qemu.go
+++ b/ciao-launcher/qemu.go
@@ -219,7 +219,7 @@ func launchQemuWithNC(params []string, fds []*os.File, ipAddress string) (int, e
 		params[len(params)-1] = fmt.Sprintf(ncString, port, ipAddress)
 		var errStr string
 
-		errStr, err = qemu.LaunchCustomQemu(context.Background(), "", params, fds, qmpGlogLogger{})
+		errStr, err = qemu.LaunchCustomQemu(context.Background(), "", params, fds, nil, qmpGlogLogger{})
 		if err == nil {
 			glog.Info("============================================")
 			glog.Infof("Connect to vm with netcat %s %d", ipAddress, port)
@@ -236,7 +236,7 @@ func launchQemuWithNC(params []string, fds []*os.File, ipAddress string) (int, e
 
 	if port == 0 || (err != nil && tries == vcTries) {
 		glog.Warning("Failed to launch qemu due to chardev error.  Relaunching without virtual console")
-		_, err = qemu.LaunchCustomQemu(context.Background(), "", params[:len(params)-4], fds, qmpGlogLogger{})
+		_, err = qemu.LaunchCustomQemu(context.Background(), "", params[:len(params)-4], fds, nil, qmpGlogLogger{})
 	}
 
 	return port, err
@@ -255,7 +255,7 @@ func launchQemuWithSpice(params []string, fds []*os.File, ipAddress string) (int
 		}
 		params[len(params)-1] = fmt.Sprintf("port=%d,addr=%s,disable-ticketing", port, ipAddress)
 		var errStr string
-		errStr, err = qemu.LaunchCustomQemu(context.Background(), "", params, fds, qmpGlogLogger{})
+		errStr, err = qemu.LaunchCustomQemu(context.Background(), "", params, fds, nil, qmpGlogLogger{})
 		if err == nil {
 			glog.Info("============================================")
 			glog.Infof("Connect to vm with spicec -h %s -p %d", ipAddress, port)
@@ -274,7 +274,7 @@ func launchQemuWithSpice(params []string, fds []*os.File, ipAddress string) (int
 	if port == 0 || (err != nil && tries == vcTries) {
 		glog.Warning("Failed to launch qemu due to spice error.  Relaunching without virtual console")
 		params = append(params[:len(params)-2], "-display", "none", "-vga", "none")
-		_, err = qemu.LaunchCustomQemu(context.Background(), "", params, fds, qmpGlogLogger{})
+		_, err = qemu.LaunchCustomQemu(context.Background(), "", params, fds, nil, qmpGlogLogger{})
 	}
 
 	return port, err
@@ -390,7 +390,7 @@ func (q *qemuV) startVM(vnicName, ipAddress, cephID string) error {
 
 	if !launchWithUI.Enabled() {
 		params = append(params, "-display", "none", "-vga", "none")
-		_, err = qemu.LaunchCustomQemu(context.Background(), "", params, fds, qmpGlogLogger{})
+		_, err = qemu.LaunchCustomQemu(context.Background(), "", params, fds, nil, qmpGlogLogger{})
 	} else if launchWithUI.String() == "spice" {
 		var port int
 		port, err = launchQemuWithSpice(params, fds, ipAddress)

--- a/ciao-launcher/qemu.go
+++ b/ciao-launcher/qemu.go
@@ -90,7 +90,7 @@ func createCloudInitISO(instanceDir, isoPath string, cfg *vmConfig, userData, me
 	}
 
 	if err := qemu.CreateCloudInitISO(context.TODO(), instanceDir, isoPath,
-		userData, metaData); err != nil {
+		userData, metaData, nil); err != nil {
 		glog.Errorf("Unable to create cloudinit iso image %v", err)
 		return err
 	}

--- a/ciao-launcher/qemu.go
+++ b/ciao-launcher/qemu.go
@@ -90,7 +90,7 @@ func createCloudInitISO(instanceDir, isoPath string, cfg *vmConfig, userData, me
 	}
 
 	if err := qemu.CreateCloudInitISO(context.TODO(), instanceDir, isoPath,
-		userData, metaData, nil); err != nil {
+		userData, metaData, childProcessCreds); err != nil {
 		glog.Errorf("Unable to create cloudinit iso image %v", err)
 		return err
 	}

--- a/ciao-launcher/simulation.go
+++ b/ciao-launcher/simulation.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"math/rand"
+	"os"
 	"sync"
 	"time"
 
@@ -93,7 +94,7 @@ VM:
 
 }
 
-func (s *simulation) startVM(vnicName, ipAddress, cephID string) error {
+func (s *simulation) startVM(vnicName, ipAddress, cephID string, fds []*os.File) error {
 	glog.Infof("startVM\n")
 
 	s.killCh = make(chan struct{})

--- a/ciao-launcher/start_instance.go
+++ b/ciao-launcher/start_instance.go
@@ -36,9 +36,14 @@ type startTimes struct {
 
 func createInstance(vm virtualizer, instanceDir string, cfg *vmConfig,
 	bridge, gatewayIP string, userData, metaData []byte) (err error) {
-	err = os.MkdirAll(instanceDir, 0755)
+	err = os.MkdirAll(instanceDir, 0775)
 	if err != nil {
-		glog.Errorf("Cannot create instance directory for VM: %v", err)
+		glog.Errorf("Cannot create instance directory: %v", err)
+		return
+	}
+	err = os.Chmod(instanceDir, 0775)
+	if err != nil {
+		glog.Errorf("Unable to set permissions for instance directory: %v", err)
 		return
 	}
 

--- a/ciao-launcher/tests/ciao-launcher-server/server.go
+++ b/ciao-launcher/tests/ciao-launcher-server/server.go
@@ -44,6 +44,7 @@ var mgmtNet string
 var diskLimit bool
 var memLimit bool
 var cephID string
+var user string
 
 var ssntpServer = &ssntp.Server{}
 
@@ -57,6 +58,7 @@ func init() {
 	flag.BoolVar(&diskLimit, "disk-limit", true, "Use disk usage limits")
 	flag.BoolVar(&memLimit, "mem-limit", true, "Use memory usage limits")
 	flag.StringVar(&cephID, "ceph-id", "ciao", "ceph client id")
+	flag.StringVar(&user, "user", "ciao", "user and group for child processes")
 }
 
 type client struct {
@@ -491,6 +493,7 @@ func createConfigFile(confPath string) error {
 		conf.Configure.Launcher.ManagementNetwork = []string{mgmtNet}
 	}
 	conf.Configure.Storage.CephID = cephID
+	conf.Configure.Launcher.ChildUser = user
 
 	d, err := yaml.Marshal(&conf)
 	if err != nil {

--- a/ciao-launcher/virtualizer.go
+++ b/ciao-launcher/virtualizer.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"errors"
+	"os"
 	"sync"
 )
 
@@ -62,7 +63,7 @@ type virtualizer interface {
 	deleteImage() error
 
 	// Boots a VM.  This method is called by START
-	startVM(vnicName, ipAddress, cephID string) error
+	startVM(vnicName, ipAddress, cephID string, fds []*os.File) error
 
 	//BUG(markus): Need to use context rather than the monitor channel to
 	//detect when we need to quit.

--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -41,6 +41,7 @@ var cert = flag.String("cert", "/etc/pki/ciao/cert-Scheduler-localhost.pem", "Se
 var cacert = flag.String("cacert", "/etc/pki/ciao/CAcert-server-localhost.pem", "CA certificate")
 var cpuprofile = flag.String("cpuprofile", "", "Write cpu profile to file")
 var heartbeat = flag.Bool("heartbeat", false, "Emit status heartbeat text")
+var prepare = flag.Bool("osprepare", false, "Install dependencies")
 var logDir = "/var/lib/ciao/logs/scheduler"
 var configURI = flag.String("configuration-uri", "file:///etc/ciao/configuration.yaml",
 	"Cluster configuration URI")
@@ -1129,6 +1130,14 @@ func setSSNTPForwardRules(sched *ssntpSchedulerServer) {
 }
 
 func initLogger() error {
+	if *prepare {
+		logToStderr := flag.Lookup("logtostderr")
+		if logToStderr != nil {
+			logToStderr.Value.Set("true")
+		}
+		return nil
+	}
+
 	logDirFlag := flag.Lookup("log_dir")
 	if logDirFlag == nil {
 		return fmt.Errorf("log_dir does not exist")
@@ -1182,9 +1191,12 @@ func main() {
 
 	glog.Info("Starting Scheduler")
 
-	logger := gloginterface.CiaoGlogLogger{}
-	osprepare.Bootstrap(context.TODO(), logger)
-	osprepare.InstallDeps(context.TODO(), schedDeps, logger)
+	if *prepare {
+		logger := gloginterface.CiaoGlogLogger{}
+		osprepare.Bootstrap(context.TODO(), logger)
+		osprepare.InstallDeps(context.TODO(), schedDeps, logger)
+		return
+	}
 
 	sched := configSchedulerServer()
 	if sched == nil {

--- a/configuration/README.md
+++ b/configuration/README.md
@@ -57,6 +57,7 @@ configure:
     mgmt_net: list [The launcher management network(s)]
     disk_limit: bool
     mem_limit: bool
+    child_user: string [ User and group under which launcher's child processes are to run.  If empty they run as the same user as launcher ]
 ```
 
 ## Configuration Examples

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -73,6 +73,7 @@ const fullValidConf = `configure:
     - 192.168.1.0/24
     disk_limit: true
     mem_limit: true
+    child_user: ciao
 `
 
 func testBlob(t *testing.T, conf *payloads.Configure, expectedBlob []byte, positive bool) {
@@ -121,6 +122,7 @@ func fillPayload(conf *payloads.Configure) {
 	conf.Configure.Controller.ClientAuthCACertPath = clientAuthCACert
 	conf.Configure.Launcher.ComputeNetwork = []string{computeNet}
 	conf.Configure.Launcher.ManagementNetwork = []string{mgmtNet}
+	conf.Configure.Launcher.ChildUser = "ciao"
 	conf.Configure.Storage.CephID = cephID
 }
 

--- a/networking/libsnnet/network.go
+++ b/networking/libsnnet/network.go
@@ -19,6 +19,7 @@ package libsnnet
 import (
 	"fmt"
 	"net"
+	"os"
 	"time"
 
 	"github.com/vishvananda/netlink"
@@ -163,7 +164,9 @@ type VnicAttrs struct {
 // Vnic represents a ciao VNIC (typically a tap or veth interface)
 type Vnic struct {
 	VnicAttrs
-	Link netlink.Link // TODO: Enhance netlink library to add specific tap type to libnetlink
+	Link   netlink.Link // TODO: Enhance netlink library to add specific tap type to libnetlink
+	FDs    []*os.File   // Need to be closed by caller
+	queues int          // Number of queues to create
 }
 
 // CnciVnic represents a ciao CNCI VNIC

--- a/networking/libsnnet/vnic.go
+++ b/networking/libsnnet/vnic.go
@@ -167,11 +167,13 @@ func createVMVnic(v *Vnic) (link netlink.Link, err error) {
 	tap := &netlink.Tuntap{
 		LinkAttrs: netlink.LinkAttrs{Name: v.LinkName},
 		Mode:      netlink.TUNTAP_MODE_TAP,
+		Queues:    v.queues,
 	}
 
 	if err := netlink.LinkAdd(tap); err != nil {
 		return nil, netError(v, "create link add %v %v", v.GlobalID, err)
 	}
+	v.FDs = tap.Fds
 
 	link, err = netlink.LinkByName(v.LinkName)
 	if err != nil {

--- a/payloads/configure.go
+++ b/payloads/configure.go
@@ -61,6 +61,7 @@ type ConfigureLauncher struct {
 	ManagementNetwork []string `yaml:"mgmt_net"`
 	DiskLimit         bool     `yaml:"disk_limit"`
 	MemoryLimit       bool     `yaml:"mem_limit"`
+	ChildUser         string   `yaml:"child_user"`
 }
 
 // ConfigureStorage contains the unmarshalled configurations for the

--- a/payloads/configure_test.go
+++ b/payloads/configure_test.go
@@ -54,6 +54,7 @@ func TestConfigureMarshal(t *testing.T) {
 	cfg.Configure.Launcher.ManagementNetwork = []string{testutil.MgmtNet}
 	cfg.Configure.Launcher.DiskLimit = false
 	cfg.Configure.Launcher.MemoryLimit = false
+	cfg.Configure.Launcher.ChildUser = testutil.User
 
 	p, _ := strconv.Atoi(testutil.CiaoPort)
 	cfg.Configure.Controller.CiaoPort = p

--- a/qemu/examples_test.go
+++ b/qemu/examples_test.go
@@ -41,7 +41,7 @@ func Example() {
 	// LaunchCustomQemu should return as soon as the instance has launched as we
 	// are using the --daemonize flag.  It will set up a unix domain socket
 	// called /tmp/qmp-socket that we can use to manage the instance.
-	_, err := qemu.LaunchCustomQemu(context.Background(), "", params, nil, nil)
+	_, err := qemu.LaunchCustomQemu(context.Background(), "", params, nil, nil, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/testutil/payloads.go
+++ b/testutil/payloads.go
@@ -99,6 +99,9 @@ const AgentUUID = "4cb19522-1e18-439a-883a-f9b2a3a95f5e"
 // VolumeUUID is a node UUID for storage tests
 const VolumeUUID = "67d86208-b46c-4465-9018-e14187d4010"
 
+// User is a user under which non-privileged ciao processes should run.
+const User = "ciao"
+
 var computeNetwork001 = payloads.NetworkStat{
 	NodeIP:  "198.51.100.1",
 	NodeMAC: "02:00:aa:cb:84:41",
@@ -317,6 +320,7 @@ const ConfigureYaml = `configure:
     - ` + MgmtNet + `
     disk_limit: false
     mem_limit: false
+    child_user: ` + User + `
 `
 
 // DeleteFailureYaml is a sample workload DeleteFailure ssntp.Error payload for test cases


### PR DESCRIPTION
This is a large PR designed to improve the security of ciao ( and fix a number of other bugs in the process ).  Essentially, it modifies ciao-deploy and the ciao services to ensure that these services run with lower privileges than before.   ciao-scheduler and ciao-controller now run as non-root (under a new user called ciao).  ciao-launcher still runs as root but with reduced capabilities.  The majority of the processes spawned by ciao-launcher now also run as the ciao user with no special privileges.  This means that the qemu instances that support VM workloads no longer run as root.

This PR also modifies the way in which ciao's dependencies are installed.  It creates a new set of services ciao-[service-name]-prepare that runs the services as root passing an -oprepare flag.  The services install any needed dependencies and exit.  They are restarted by the existing systemd unit files which now run them with reduced privileges.

The PR also fixes a number of other issues

1.  It is now possible for VM instances to take advantage of virtio-net multiqueue support potentially improving their network performance.  We're not currently taking advantage of this yet, but enabling it is now a 1 line change.
2. The introduction of the ciao-[service]-prepare unit files fixes a race condition noticeable on clean installs on fedora and clear.  Notable ciao-deploy returns before the cluster is fully set up and before launching is ready to receive workloads.

Fixes: https://github.com/ciao-project/ciao/issues/669