### PR TITLE
BAT: Fix a race condition in TestInstanceLimited

### DIFF
--- a/_release/bat/quotas_bat/quotas_bat_test.go
+++ b/_release/bat/quotas_bat/quotas_bat_test.go
@@ -214,9 +214,11 @@ func launchMultipleInstances(ctx context.Context, t *testing.T, tenantID string,
 
 		scheduled, err := bat.WaitForInstancesLaunch(ctx, "", instances, false)
 		defer func() {
-			_, err := bat.DeleteInstances(ctx, "", scheduled)
-			if err != nil {
-				t.Errorf("Failed to delete instances: %v", err)
+			for _, s := range scheduled {
+				err := bat.DeleteInstanceAndWait(ctx, "", s)
+				if err != nil {
+					t.Errorf("Failed to delete instances: %v", err)
+				}
 			}
 		}()
 		if err != nil {


### PR DESCRIPTION
This test was creating and deleting instances but was not waiting for the
instances to be fully deleted before terminating.  This led to a race
condition in which instances could still be alive when the subsequent
test started.  As this test assumed no instances on start this race led
to an occasional failure of the following test (TestInstanceUsageAfterDenial).
This commit fixes the problem by ensuring that all instances have been
fully deleted before TestInstanceLimited terminates.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>