### PR TITLE
ciao-launcher: Fix hard-reset, a race condition and some logs

### DIFF
--- a/ciao-launcher/delete_instance.go
+++ b/ciao-launcher/delete_instance.go
@@ -41,7 +41,7 @@ func deleteVnic(instanceDir string, conn serverConn) {
 	}
 }
 
-func processDelete(vm virtualizer, instanceDir string, conn serverConn, running ovsRunningState) error {
+func processDelete(vm virtualizer, instanceDir string, conn serverConn, creating bool) error {
 
 	// We have to ignore these errors for the time being.  There's no way to distinguish
 	// between the various sort of errors that docker can return.  We could be getting
@@ -50,7 +50,7 @@ func processDelete(vm virtualizer, instanceDir string, conn serverConn, running 
 
 	_ = vm.deleteImage()
 
-	if networking && running != ovsPending {
+	if networking && !creating {
 		glog.Info("Deleting Vnic")
 		deleteVnic(instanceDir, conn)
 	}

--- a/ciao-launcher/docker_network.go
+++ b/ciao-launcher/docker_network.go
@@ -43,7 +43,11 @@ func createDockerVnic(vnicCfg *libsnnet.VnicConfig) (*libsnnet.Vnic, *libsnnet.S
 	// of launcher.  Should the network really fail to be created
 	// the container will not launch.
 
-	_ = createDockerNetwork(context.Background(), info)
+	err = createDockerNetwork(context.Background(), info)
+	if err != nil {
+		glog.Infof("Failed to create docker network %s.  May already exist? : %v",
+			info.Bridge, err)
+	}
 	return vnic, event, info, nil
 }
 

--- a/ciao-launcher/hard_reset.go
+++ b/ciao-launcher/hard_reset.go
@@ -167,4 +167,13 @@ func purgeLauncherState() {
 	if err = os.RemoveAll(dataDir); err != nil {
 		glog.Warningf("Unable to delete data dir %s: %v", dataDir, err)
 	}
+
+	if err = os.RemoveAll(instancesDir); err != nil {
+		glog.Warningf("Unable to delete instances dir %s: %v", instancesDir, err)
+	}
+
+	lockPath := path.Join(lockDir, lockFile)
+	if err = os.RemoveAll(lockPath); err != nil {
+		glog.Warningf("Unable to delete lock file %s: %v", lockPath, err)
+	}
 }

--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -184,8 +184,7 @@ func processCommand(conn serverConn, cmd *cmdWrapper, ovsCh chan<- interface{}) 
 			wg.Add(1)
 			go func(i ovsInstance) {
 				i.cmdCh <- &insDeleteCmd{
-					stop:    true,
-					running: i.running,
+					stop: true,
 				}
 				errCh := make(chan error)
 				ovsCh <- &ovsRemoveCmd{i.instance, errCh}
@@ -236,7 +235,6 @@ func processInstanceCommand(conn serverConn, cmd *cmdWrapper, ovsCh chan<- inter
 			return
 		}
 		delCmd = insCmd
-		delCmd.running = insState.running
 	default:
 		target = insCmdChannel(cmd.instance, ovsCh)
 	}

--- a/ciao-launcher/overseer.go
+++ b/ciao-launcher/overseer.go
@@ -55,7 +55,6 @@ type ovsGetCmd struct {
 
 type ovsInstance struct {
 	instance string
-	running  ovsRunningState
 	cmdCh    chan<- interface{}
 }
 
@@ -424,7 +423,6 @@ func (ovs *overseer) processGetAllCommand(cmd *ovsGetAllCmd) {
 		res.instances = append(res.instances,
 			ovsInstance{
 				instance: k,
-				running:  v.running,
 				cmdCh:    v.cmdCh,
 			})
 	}

--- a/ciao-launcher/process_stats.go
+++ b/ciao-launcher/process_stats.go
@@ -35,7 +35,7 @@ func parseProcSmaps(smapsPath string) int {
 	smaps, err := os.Open(smapsPath)
 	if err != nil {
 		if glog.V(1) {
-			glog.Warning("Unable to open %s: %v", smapsPath, err)
+			glog.Warningf("Unable to open %s: %v", smapsPath, err)
 		}
 		return -1
 	}
@@ -68,7 +68,7 @@ func parseProcStat(statPath string) int64 {
 	stat, err := os.Open(statPath)
 	if err != nil {
 		if glog.V(1) {
-			glog.Warning("Unable to open %s: %v", statPath, err)
+			glog.Warningf("Unable to open %s: %v", statPath, err)
 		}
 		return -1
 	}

--- a/ciao-launcher/start_instance.go
+++ b/ciao-launcher/start_instance.go
@@ -115,6 +115,9 @@ func processStart(cmd *insStartCmd, instanceDir string, vm virtualizer, conn ser
 	err = createInstance(vm, instanceDir, cfg, bridge, gatewayIP, cmd.userData,
 		cmd.metaData)
 	if err != nil {
+		if vnicCfg != nil {
+			destroyVnic(conn, vnicCfg)
+		}
 		return nil, &startError{err, payloads.ImageFailure, cmd.cfg.Restart}
 	}
 
@@ -122,6 +125,9 @@ func processStart(cmd *insStartCmd, instanceDir string, vm virtualizer, conn ser
 
 	err = vm.startVM(vnicName, getNodeIPAddress(), cephID)
 	if err != nil {
+		if vnicCfg != nil {
+			destroyVnic(conn, vnicCfg)
+		}
 		return nil, &startError{err, payloads.LaunchFailure, cmd.cfg.Restart}
 	}
 


### PR DESCRIPTION
This PR fixes a number of small issues with launcher.

1. There was a nasty race condition when deleting VNICs of instances.
2. Hard-reset was not cleaning all the files and directories created launcher.
3. There were a few little issues with logs scatter throughout the code.