### PR TITLE
osprepare: Remove cephfs as a core dependency

### DIFF
--- a/osprepare/osprepare.go
+++ b/osprepare/osprepare.go
@@ -83,11 +83,9 @@ func (cur *PackageRequirements) Append(newReqs PackageRequirements) {
 // functionality across all Ciao components
 var BootstrapRequirements = PackageRequirements{
 	"ubuntu": {
-		{"/usr/bin/cephfs", "ceph-fs-common"},
 		{"/usr/bin/ceph", "ceph-common"},
 	},
 	"fedora": {
-		{"/usr/bin/cephfs", "ceph"},
 		{"/usr/bin/ceph", "ceph-common"},
 	},
 	"clearlinux": {


### PR DESCRIPTION
osprepare was installing or at least attempting to install cephfs as a
core dependency.  We no longer use cephfs and haven't for over a year.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>