### PR TITLE
ciao-deploy: do not use latest for cnci version, use last known good

### DIFF
--- a/ciao-deploy/deploy/utils.go
+++ b/ciao-deploy/deploy/utils.go
@@ -47,6 +47,32 @@ func DefaultImageCacheDir() string {
 	return path.Join(u.HomeDir, ".cache", "ciao", "images")
 }
 
+// CleanupImages will remove all images from the cache directory that
+// match a specific pattern. Images that match this pattern but should
+// be preserved can be specified in the "keep" slice.
+func CleanupImages(pattern string, keep []string, imageCacheDir string) error {
+	imagePath := fmt.Sprintf("%s/%s", imageCacheDir, pattern)
+
+	matches, err := filepath.Glob(imagePath)
+	if err != nil {
+		return errors.Wrap(err, "Unable to clean old images")
+	}
+
+	keepMap := make(map[string]bool)
+	for _, k := range keep {
+		keepMap[k] = true
+	}
+
+	for _, m := range matches {
+		if keepMap[m] {
+			continue
+		}
+
+		_ = os.Remove(m)
+	}
+	return nil
+}
+
 // DownloadImage checks for a cached image in the cache directory and downloads
 // otherwise. The returned string is the path to the file and the boolean
 // indicates if it was downloaded on this function call.


### PR DESCRIPTION
It turns out that the "latest" file that is located on clearlinux.org
only refers to the latest generated image, but that image may not
necessarily end up in download.clearlinux.org/image if it does not
pass QA for some reason. Therefore, any cloud image located in
clearlinux.org/image is the last known good image and should be
used. Modify getCNCIURL() to download the images listing and look
for the cloud image filename to use from there.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>