### PR TITLE
Use image names in workload definition

### DIFF
--- a/_release/bat/workload_bat/workload_bat_test.go
+++ b/_release/bat/workload_bat/workload_bat_test.go
@@ -44,8 +44,8 @@ const vmWorkloadImageName = "ubuntu-server-16.04"
 func getWorkloadSource(ctx context.Context, t *testing.T, tenant string) bat.Source {
 	// get the Image ID to use.
 	source := bat.Source{
-		Type: "image",
-		ID:   vmWorkloadImageName,
+		Type:   "image",
+		Source: vmWorkloadImageName,
 	}
 
 	return source

--- a/_release/bat/workload_bat/workload_bat_test.go
+++ b/_release/bat/workload_bat/workload_bat_test.go
@@ -39,30 +39,13 @@ users:
 ...
 `
 
-const vmWorkloadImageName = "Ubuntu Server 16.04"
+const vmWorkloadImageName = "ubuntu-server-16.04"
 
 func getWorkloadSource(ctx context.Context, t *testing.T, tenant string) bat.Source {
 	// get the Image ID to use.
 	source := bat.Source{
 		Type: "image",
-	}
-
-	// if we pass in "" for tenant, we get whatever the CIAO_USERNAME value
-	// is set to.
-	images, err := bat.GetImages(ctx, false, tenant)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for ID, image := range images {
-		if image.Name != vmWorkloadImageName {
-			continue
-		}
-		source.ID = ID
-	}
-
-	if source.ID == "" {
-		t.Fatalf("vm Image %s not available", vmWorkloadImageName)
+		ID:   vmWorkloadImageName,
 	}
 
 	return source

--- a/bat/workload.go
+++ b/bat/workload.go
@@ -37,8 +37,8 @@ import (
 // Source is provided to the disk structure to indicate whether the
 // disk should be cloned from a volume or an image.
 type Source struct {
-	Type string `yaml:"service"`
-	ID   string `yaml:"id"`
+	Type   string `yaml:"service"`
+	Source string `yaml:"source"`
 }
 
 // Disk describes the storage for the workload definition.

--- a/bat/workload.go
+++ b/bat/workload.go
@@ -37,7 +37,7 @@ import (
 // Source is provided to the disk structure to indicate whether the
 // disk should be cloned from a volume or an image.
 type Source struct {
-	Type   string `yaml:"service"`
+	Type   string `yaml:"type"`
 	Source string `yaml:"source"`
 }
 

--- a/ciao-cli/examples/fedora_cloud.yaml
+++ b/ciao-cli/examples/fedora_cloud.yaml
@@ -8,6 +8,6 @@ cloud_init: fedora_vm.yaml
 disks:
   - source:
        service: image
-       id: "73a86d7e-93c0-480e-9c41-ab42f69b7799"
+       source: "73a86d7e-93c0-480e-9c41-ab42f69b7799"
     ephemeral: true
     bootable: true

--- a/ciao-cli/examples/fedora_cloud.yaml
+++ b/ciao-cli/examples/fedora_cloud.yaml
@@ -7,7 +7,7 @@ requirements:
 cloud_init: fedora_vm.yaml
 disks:
   - source:
-       service: image
+       type: image
        source: "73a86d7e-93c0-480e-9c41-ab42f69b7799"
     ephemeral: true
     bootable: true

--- a/ciao-cli/examples/fedora_cloud_disk.yaml
+++ b/ciao-cli/examples/fedora_cloud_disk.yaml
@@ -7,7 +7,7 @@ requirements:
 cloud_init: "fedora_vm.yaml"
 disks:
 - source:
-    service: image
+    type: image
     source: "73a86d7e-93c0-480e-9c41-ab42f69b7799"
   bootable: true
   ephemeral: true

--- a/ciao-cli/examples/fedora_cloud_disk.yaml
+++ b/ciao-cli/examples/fedora_cloud_disk.yaml
@@ -8,7 +8,7 @@ cloud_init: "fedora_vm.yaml"
 disks:
 - source:
     service: image
-    id: "73a86d7e-93c0-480e-9c41-ab42f69b7799"
+    source: "73a86d7e-93c0-480e-9c41-ab42f69b7799"
   bootable: true
   ephemeral: true
 - size: 20

--- a/ciao-cli/image.go
+++ b/ciao-cli/image.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"regexp"
 	"text/template"
 
 	"github.com/ciao-project/ciao/ciao-controller/types"
@@ -73,6 +74,11 @@ func (cmd *imageAddCommand) parseArgs(args []string) []string {
 func (cmd *imageAddCommand) run(args []string) error {
 	if cmd.name == "" {
 		return errors.New("Missing required -name parameter")
+	}
+
+	r := regexp.MustCompile("^[a-z0-9-.]{1,64}$")
+	if !r.MatchString(cmd.name) {
+		return errors.New("Requested name must be between 1 and 64 lowercase letters, numbers, hyphens and dots")
 	}
 
 	if cmd.file == "" {

--- a/ciao-cli/instance.go
+++ b/ciao-cli/instance.go
@@ -90,7 +90,7 @@ func (cmd *instanceAddCommand) validateAddCommandArgs() {
 	}
 
 	if cmd.name != "" {
-		r := regexp.MustCompile("^[a-z0-9-]{1,64}?$")
+		r := regexp.MustCompile("^[a-z0-9-]{1,64}$")
 		if !r.MatchString(cmd.name) {
 			errorf("Requested name must be between 1 and 64 lowercase letters, numbers and hyphens")
 		}

--- a/ciao-cli/workload.go
+++ b/ciao-cli/workload.go
@@ -130,8 +130,8 @@ The create flags are:
 }
 
 type source struct {
-	Type types.SourceType `yaml:"service"`
-	ID   string           `yaml:"id"`
+	Type   types.SourceType `yaml:"service"`
+	Source string           `yaml:"source"`
 }
 
 type disk struct {
@@ -182,7 +182,7 @@ func optToReqStorage(opt workloadOptions) ([]types.StorageResource, error) {
 
 			if disk.Source.Type != types.Empty {
 				res.SourceType = disk.Source.Type
-				res.Source = disk.Source.ID
+				res.Source = disk.Source.Source
 
 				if res.Source == "" {
 					return nil, errors.New("Invalid workload yaml: when using a source an id must also be specified")
@@ -266,8 +266,8 @@ func outputWorkload(w types.Workload) {
 		}
 
 		src := source{
-			Type: s.SourceType,
-			ID:   s.Source,
+			Type:   s.SourceType,
+			Source: s.Source,
 		}
 
 		d.Source = src

--- a/ciao-cli/workload.go
+++ b/ciao-cli/workload.go
@@ -130,7 +130,7 @@ The create flags are:
 }
 
 type source struct {
-	Type   types.SourceType `yaml:"service"`
+	Type   types.SourceType `yaml:"type"`
 	Source string           `yaml:"source"`
 }
 

--- a/ciao-cli/workload.go
+++ b/ciao-cli/workload.go
@@ -182,9 +182,9 @@ func optToReqStorage(opt workloadOptions) ([]types.StorageResource, error) {
 
 			if disk.Source.Type != types.Empty {
 				res.SourceType = disk.Source.Type
-				res.SourceID = disk.Source.ID
+				res.Source = disk.Source.ID
 
-				if res.SourceID == "" {
+				if res.Source == "" {
 					return nil, errors.New("Invalid workload yaml: when using a source an id must also be specified")
 				}
 			} else {
@@ -267,7 +267,7 @@ func outputWorkload(w types.Workload) {
 
 		src := source{
 			Type: s.SourceType,
-			ID:   s.SourceID,
+			ID:   s.Source,
 		}
 
 		d.Source = src

--- a/ciao-controller/compute.go
+++ b/ciao-controller/compute.go
@@ -162,7 +162,7 @@ func (c *controller) CreateServer(tenant string, server api.CreateServerRequest)
 
 	if server.Server.Name != "" {
 		// Between 1 and 64 (HOST_NAME_MAX) alphanum (+ "-")
-		r := regexp.MustCompile("^[a-z0-9-]{1,64}?$")
+		r := regexp.MustCompile("^[a-z0-9-]{1,64}$")
 		if !r.MatchString(server.Server.Name) {
 			return server, types.ErrBadName
 		}

--- a/ciao-controller/compute.go
+++ b/ciao-controller/compute.go
@@ -164,7 +164,7 @@ func (c *controller) CreateServer(tenant string, server api.CreateServerRequest)
 		// Between 1 and 64 (HOST_NAME_MAX) alphanum (+ "-")
 		r := regexp.MustCompile("^[a-z0-9-]{1,64}?$")
 		if !r.MatchString(server.Server.Name) {
-			return server, fmt.Errorf("Requested name must be between 1 and 64 lowercase letters, numbers and hyphens")
+			return server, types.ErrBadName
 		}
 	}
 

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -1214,7 +1214,7 @@ func TestGetStorageForVolume(t *testing.T) {
 		Bootable:   true,
 		Ephemeral:  false,
 		SourceType: types.VolumeService,
-		SourceID:   sourceVolume.ID,
+		Source:     sourceVolume.ID,
 	}
 
 	pl, err := getStorage(ctl, s, tenant.ID, "")
@@ -1265,7 +1265,7 @@ func TestGetStorageForImage(t *testing.T) {
 		Bootable:   true,
 		Ephemeral:  false,
 		SourceType: types.ImageService,
-		SourceID:   filepath.Base(tmpfile.Name()),
+		Source:     filepath.Base(tmpfile.Name()),
 	}
 
 	pl, err := getStorage(ctl, s, tenant.ID, "")
@@ -1327,7 +1327,7 @@ func TestStorageConfig(t *testing.T) {
 		Bootable:   true,
 		Ephemeral:  false,
 		SourceType: types.ImageService,
-		SourceID:   info.Name(),
+		Source:     info.Name(),
 	}
 
 	wls[0].Storage = []types.StorageResource{s}

--- a/ciao-controller/image.go
+++ b/ciao-controller/image.go
@@ -201,11 +201,11 @@ func (c *controller) DeleteImage(tenantID, imageID string) error {
 	return nil
 }
 
-// GetImage will get the raw image data
+// GetImage gets image metadata after checking permissions
 func (c *controller) GetImage(tenantID, imageID string) (types.Image, error) {
 	glog.Infof("Getting Image [%v] from [%v]", imageID, tenantID)
 
-	image, err := c.ds.GetImage(imageID)
+	image, err := c.ds.ResolveImage(imageID)
 	if err != nil {
 		return types.Image{}, err
 	}

--- a/ciao-controller/image.go
+++ b/ciao-controller/image.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"time"
 
 	"github.com/ciao-project/ciao/ciao-controller/api"
@@ -42,6 +43,11 @@ func (c *controller) CreateImage(tenantID string, req api.CreateImageRequest) (t
 			glog.Errorf("Error on parsing UUID: %v", err)
 			return types.Image{}, api.ErrBadUUID
 		}
+	}
+
+	r := regexp.MustCompile("^[a-z0-9-.]{1,64}$")
+	if !r.MatchString(req.Name) {
+		return types.Image{}, types.ErrBadName
 	}
 
 	i := types.Image{

--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -264,14 +264,14 @@ func getStorage(c *controller, s types.StorageResource, tenant string, instanceI
 	var err error
 	switch s.SourceType {
 	case types.ImageService:
-		device, err = c.CreateBlockDeviceFromSnapshot(s.SourceID, "ciao-image")
+		device, err = c.CreateBlockDeviceFromSnapshot(s.Source, "ciao-image")
 		if err != nil {
 			glog.Errorf("Unable to get block device for image: %v", err)
 			return payloads.StorageResource{}, err
 		}
 
 	case types.VolumeService:
-		device, err = c.CopyBlockDevice(s.SourceID)
+		device, err = c.CopyBlockDevice(s.Source)
 		if err != nil {
 			return payloads.StorageResource{}, err
 		}

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -2518,7 +2518,7 @@ users:
 		Bootable:   true,
 		Ephemeral:  true,
 		SourceType: types.ImageService,
-		SourceID:   "4e16e743-265a-4bf2-9fd1-57ada0b28904",
+		Source:     "4e16e743-265a-4bf2-9fd1-57ada0b28904",
 		Internal:   true,
 	}
 

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -192,6 +192,7 @@ type Datastore struct {
 
 	imageLock      *sync.RWMutex
 	images         map[string]types.Image
+	imagesByName   map[string]string
 	publicImages   []string
 	internalImages []string
 
@@ -223,12 +224,14 @@ func (ds *Datastore) initExternalIPs() {
 func (ds *Datastore) initImages() error {
 	ds.imageLock = &sync.RWMutex{}
 	ds.images = make(map[string]types.Image)
+	ds.imagesByName = make(map[string]string)
 	images, err := ds.db.getImages()
 	if err != nil {
 		return errors.Wrap(err, "error getting images from database")
 	}
 	for _, i := range images {
 		ds.images[i.ID] = i
+		ds.imagesByName[i.Name] = i.ID
 
 		if i.Visibility == types.Public {
 			ds.publicImages = append(ds.publicImages, i.ID)
@@ -2579,6 +2582,10 @@ func (ds *Datastore) AddImage(i types.Image) error {
 		return api.ErrAlreadyExists
 	}
 
+	if _, ok := ds.imagesByName[i.Name]; ok {
+		return api.ErrAlreadyExists
+	}
+
 	err := ds.db.updateImage(i)
 	if err != nil {
 		return errors.Wrap(err, "Unable to add image to database")
@@ -2597,6 +2604,7 @@ func (ds *Datastore) AddImage(i types.Image) error {
 	}
 
 	ds.images[i.ID] = i
+	ds.imagesByName[i.Name] = i.ID
 
 	if i.Visibility == types.Public {
 		ds.publicImages = append(ds.publicImages, i.ID)
@@ -2630,6 +2638,11 @@ func (ds *Datastore) UpdateImage(i types.Image) error {
 
 	ds.images[i.ID] = i
 
+	if oldImage.Name != i.Name {
+		delete(ds.imagesByName, oldImage.Name)
+		ds.imagesByName[i.Name] = i.ID
+	}
+
 	return nil
 }
 
@@ -2639,6 +2652,24 @@ func (ds *Datastore) GetImage(ID string) (types.Image, error) {
 	defer ds.imageLock.RUnlock()
 
 	image, ok := ds.images[ID]
+	if !ok {
+		return types.Image{}, api.ErrNoImage
+	}
+
+	return image, nil
+}
+
+// ResolveImage retrieves an image by name or ID
+func (ds *Datastore) ResolveImage(name string) (types.Image, error) {
+	ds.imageLock.RLock()
+	defer ds.imageLock.RUnlock()
+
+	id, ok := ds.imagesByName[name]
+	if ok {
+		name = id
+	}
+
+	image, ok := ds.images[name]
 	if !ok {
 		return types.Image{}, api.ErrNoImage
 	}
@@ -2728,6 +2759,7 @@ func (ds *Datastore) DeleteImage(ID string) error {
 	}
 
 	delete(ds.images, ID)
+	delete(ds.imagesByName, image.Name)
 
 	return nil
 }

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -2734,6 +2734,80 @@ func TestAddRemoveDuplicateImage(t *testing.T) {
 	}
 }
 
+func TestAddRemoveDuplicateNameImage(t *testing.T) {
+	tenant, err := addTestTenant()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	i := types.Image{
+		ID:         uuid.Generate().String(),
+		Name:       "test-image-1",
+		Visibility: types.Private,
+		TenantID:   tenant.ID,
+	}
+
+	err = ds.AddImage(i)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	i2 := types.Image{
+		ID:         uuid.Generate().String(),
+		Name:       "test-image-1",
+		Visibility: types.Private,
+		TenantID:   tenant.ID,
+	}
+
+	err = ds.AddImage(i2)
+	if err != api.ErrAlreadyExists {
+		t.Fatal("Expected error when adding duplicate")
+	}
+
+	err = ds.DeleteImage(i.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ds.DeleteImage(i2.ID)
+	if err != api.ErrNoImage {
+		t.Fatal("Expected error when trying to delete again")
+	}
+}
+
+func TestResolveImage(t *testing.T) {
+	tenant, err := addTestTenant()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	i := types.Image{
+		ID:         uuid.Generate().String(),
+		Name:       "test-image-1",
+		Visibility: types.Private,
+		TenantID:   tenant.ID,
+	}
+
+	err = ds.AddImage(i)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	i2, err := ds.ResolveImage(i.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	i3, err := ds.ResolveImage(i.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(i2, i3) {
+		t.Fatal("Expected images returned by name and ID resolution equal")
+	}
+}
+
 var ds *Datastore
 
 var workloadsPath = flag.String("workloads_path", "../../workloads", "path to yaml files")

--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -622,7 +622,7 @@ func (ds *sqliteDB) getConfig(ID string) (string, error) {
 
 // lock must be held by caller
 func (ds *sqliteDB) createWorkloadStorage(tx *sql.Tx, workloadID string, storage *types.StorageResource) error {
-	_, err := tx.Exec("INSERT INTO workload_storage (workload_id, volume_id, bootable, ephemeral, size, source_type, source_id, tag) VALUES (?, ?, ?, ?, ?, ?, ?, ?)", workloadID, storage.ID, storage.Bootable, storage.Ephemeral, storage.Size, string(storage.SourceType), storage.SourceID, storage.Tag)
+	_, err := tx.Exec("INSERT INTO workload_storage (workload_id, volume_id, bootable, ephemeral, size, source_type, source_id, tag) VALUES (?, ?, ?, ?, ?, ?, ?, ?)", workloadID, storage.ID, storage.Bootable, storage.Ephemeral, storage.Size, string(storage.SourceType), storage.Source, storage.Tag)
 
 	return err
 }
@@ -651,7 +651,7 @@ func (ds *sqliteDB) getWorkloadStorage(ID string) ([]types.StorageResource, erro
 
 	for rows.Next() {
 		var r types.StorageResource
-		err := rows.Scan(&r.ID, &r.Bootable, &r.Ephemeral, &r.Size, &sourceType, &r.SourceID, &r.Tag)
+		err := rows.Scan(&r.ID, &r.Bootable, &r.Ephemeral, &r.Size, &sourceType, &r.Source, &r.Tag)
 
 		if err != nil {
 			return []types.StorageResource{}, err

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -607,6 +607,9 @@ var (
 
 	// ErrWorkloadInUse is returned by DeleteWorkload when an instance of a workload is still active.
 	ErrWorkloadInUse = errors.New("Workload definition still in use")
+
+	// ErrBadName is returned when a name doesn't match the requirements
+	ErrBadName = errors.New("Requested name doesn't match requirements")
 )
 
 // Link provides a url and relationship for a resource.

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -66,9 +66,9 @@ type StorageResource struct {
 	// Needed only for new storage.
 	SourceType SourceType `json:"source_type"`
 
-	// SourceID represents the ID of either the image or the volume
+	// Source represents the ID or name of either the image or the volume
 	// that the storage resource is based on.
-	SourceID string `json:"source_id"`
+	Source string `json:"source_id"`
 
 	// Tag is a piece of abitrary search/sort identifier text
 	Tag string

--- a/ciao-controller/workload.go
+++ b/ciao-controller/workload.go
@@ -47,7 +47,7 @@ func validateContainerWorkload(req types.Workload) error {
 }
 
 func (c *controller) validateWorkloadStorageSourceID(storage *types.StorageResource, tenantID string) error {
-	if storage.SourceID == "" {
+	if storage.Source == "" {
 		// you may only use no source id with empty type
 		if storage.SourceType != types.Empty {
 			return types.ErrBadRequest
@@ -55,14 +55,14 @@ func (c *controller) validateWorkloadStorageSourceID(storage *types.StorageResou
 	}
 
 	if storage.SourceType == types.ImageService {
-		_, err := c.GetImage(tenantID, storage.SourceID)
+		_, err := c.GetImage(tenantID, storage.Source)
 		if err != nil {
 			return types.ErrBadRequest
 		}
 	}
 
 	if storage.SourceType == types.VolumeService {
-		_, err := c.ShowVolumeDetails(tenantID, storage.SourceID)
+		_, err := c.ShowVolumeDetails(tenantID, storage.Source)
 		if err != nil {
 			return types.ErrBadRequest
 		}

--- a/ciao-deploy/deploy/cnci.go
+++ b/ciao-deploy/deploy/cnci.go
@@ -212,7 +212,7 @@ func CreateCNCIImage(ctx context.Context, anchorCertPath string, caCertPath stri
 	imageOpts := &bat.ImageOptions{
 		ID:         cnciImageID,
 		Visibility: "internal",
-		Name:       "ciao CNCI image",
+		Name:       "ciao-cnci",
 	}
 
 	fmt.Printf("Uploading image as %s\n", imageOpts.ID)

--- a/ciao-deploy/deploy/workloads.go
+++ b/ciao-deploy/deploy/workloads.go
@@ -315,8 +315,8 @@ func (wd *baseWorkload) CreateWorkload(ctx context.Context, sshPublickey string,
 		opts.Disks = []bat.Disk{
 			{
 				Source: &bat.Source{
-					Type: "image",
-					ID:   wd.imageID,
+					Type:   "image",
+					Source: wd.imageID,
 				},
 				Ephemeral: true,
 				Bootable:  true,

--- a/ciao-deploy/deploy/workloads.go
+++ b/ciao-deploy/deploy/workloads.go
@@ -85,7 +85,7 @@ type workloadDetails interface {
 var images = []workloadDetails{
 	&baseWorkload{
 		url:       "https://download.fedoraproject.org/pub/fedora/linux/releases/24/CloudImages/x86_64/images/Fedora-Cloud-Base-24-1.2.x86_64.qcow2",
-		imageName: "Fedora Cloud Base 24-1.2",
+		imageName: "fedora-cloud-base-24-1.2",
 		extra:     true,
 		cloudInit: vmCloudInit,
 		opts: bat.WorkloadOptions{
@@ -100,7 +100,7 @@ var images = []workloadDetails{
 	},
 	&baseWorkload{
 		url:       "https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img",
-		imageName: "Ubuntu Server 16.04",
+		imageName: "ubuntu-server-16.04",
 		extra:     false,
 		cloudInit: vmCloudInit,
 		opts: bat.WorkloadOptions{
@@ -306,7 +306,7 @@ func (wd *baseWorkload) Upload(ctx context.Context) error {
 }
 
 func (cwd *clearWorkload) Upload(ctx context.Context) error {
-	return cwd.wd.upload(ctx, cwd.wd.localPath, fmt.Sprintf("Clear Linux %s", cwd.version))
+	return cwd.wd.upload(ctx, cwd.wd.localPath, fmt.Sprintf("clear-linux-%s", cwd.version))
 }
 
 func (wd *baseWorkload) CreateWorkload(ctx context.Context, sshPublickey string, password string) error {

--- a/k8s/kubicle/cloudinit.go
+++ b/k8s/kubicle/cloudinit.go
@@ -26,7 +26,7 @@ cloud_init: "{{.UserDataFile}}"
 disks:
   - source:
        service: image
-       id: "{{.ImageUUID}}"
+       source: "{{.ImageUUID}}"
     size: {{.DiskGiB}}
     ephemeral: true
     bootable: true

--- a/k8s/kubicle/cloudinit.go
+++ b/k8s/kubicle/cloudinit.go
@@ -25,7 +25,7 @@ requirements:
 cloud_init: "{{.UserDataFile}}"
 disks:
   - source:
-       service: image
+       type: image
        source: "{{.ImageUUID}}"
     size: {{.DiskGiB}}
     ephemeral: true


### PR DESCRIPTION
This PR enables the use of image names (and enforces some rules on them) in workload definitions as part of the storage sources.

The name is resolved at workload creation time to an ID and that is what is preserved in the database. The PR also makes some cleanups related to the code adjacent to this change.