### PR TITLE
ciao-controller: Remove default CNCI password

### DIFF
--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -2503,9 +2503,17 @@ func (ds *Datastore) GenerateCNCIWorkload(vcpus int, memMB int, diskMB int, key 
 #cloud-config
 users:
   - name: cloud-admin
-    gecos: CIAO Cloud Admin
+	gecos: CIAO Cloud Admin
+	`
+
+	if password != "" {
+		config += `
     lock-passwd: false
-    passwd: ` + password + `
+	passwd: ` + password + `
+	`
+	}
+
+	config += `
     sudo: ALL=(ALL) NOPASSWD:ALL
     ssh-authorized-keys:
     - ` + key + `

--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -72,11 +72,6 @@ var clientCertCAPath = "/etc/pki/ciao/auth-CA.pem"
 
 var cephID = flag.String("ceph_id", "", "ceph client id")
 
-var adminSSHKey = ""
-
-// default password set to "ciao"
-var adminPassword = "$6$rounds=4096$w9I3hR4g/hu$AnYjaC2DfznbPSG3vxsgtgAS4mJwWBkcR74Y/KHNB5OsfAlA4gpU5j6CHWMOkkt9j.9d7OYJXJ4icXHzKXTAO."
-
 func init() {
 	flag.Parse()
 
@@ -200,11 +195,8 @@ func main() {
 	cnciMem := clusterConfig.Configure.Controller.CNCIMem
 	cnciDisk := clusterConfig.Configure.Controller.CNCIDisk
 
-	adminSSHKey = clusterConfig.Configure.Controller.AdminSSHKey
-
-	if clusterConfig.Configure.Controller.AdminPassword != "" {
-		adminPassword = clusterConfig.Configure.Controller.AdminPassword
-	}
+	adminSSHKey := clusterConfig.Configure.Controller.AdminSSHKey
+	adminPassword := clusterConfig.Configure.Controller.AdminPassword
 
 	if clusterConfig.Configure.Controller.ClientAuthCACertPath != "" {
 		clientCertCAPath = clusterConfig.Configure.Controller.ClientAuthCACertPath


### PR DESCRIPTION
If the user didn't specify a CNCI user password we would default to the well
known "ciao". It is not required, nor expected, for an admin to need to
be able to login (and thus specify a password.)

Signed-off-by: Rob Bradford <robert.bradford@intel.com>