### PR TITLE
Remove CNCI admin password

### DIFF
--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -2094,7 +2094,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	ctl.ds.GenerateCNCIWorkload(4, 128, 128, "", "")
+	ctl.ds.GenerateCNCIWorkload(4, 128, 128, "")
 
 	ctl.qs.Init()
 

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -2497,15 +2497,14 @@ func (ds *Datastore) UnMapExternalIP(address string) error {
 
 // GenerateCNCIWorkload is used to create a workload definition for the CNCI.
 // This function should be called prior to any workload launch.
-func (ds *Datastore) GenerateCNCIWorkload(vcpus int, memMB int, diskMB int, key string, password string) {
+func (ds *Datastore) GenerateCNCIWorkload(vcpus int, memMB int, diskMB int, key string) {
 	// generate the CNCI workload.
 	config := `---
 #cloud-config
 users:
   - name: cloud-admin
     gecos: CIAO Cloud Admin
-    lock-passwd: false
-    passwd: ` + password + `
+    lock-passwd: true
     sudo: ALL=(ALL) NOPASSWD:ALL
     ssh-authorized-keys:
     - ` + key + `

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -2829,7 +2829,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	ds.GenerateCNCIWorkload(4, 128, 128, "", "")
+	ds.GenerateCNCIWorkload(4, 128, 128, "")
 
 	code := m.Run()
 

--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -74,9 +74,6 @@ var cephID = flag.String("ceph_id", "", "ceph client id")
 
 var adminSSHKey = ""
 
-// default password set to "ciao"
-var adminPassword = "$6$rounds=4096$w9I3hR4g/hu$AnYjaC2DfznbPSG3vxsgtgAS4mJwWBkcR74Y/KHNB5OsfAlA4gpU5j6CHWMOkkt9j.9d7OYJXJ4icXHzKXTAO."
-
 func init() {
 	flag.Parse()
 
@@ -202,15 +199,11 @@ func main() {
 
 	adminSSHKey = clusterConfig.Configure.Controller.AdminSSHKey
 
-	if clusterConfig.Configure.Controller.AdminPassword != "" {
-		adminPassword = clusterConfig.Configure.Controller.AdminPassword
-	}
-
 	if clusterConfig.Configure.Controller.ClientAuthCACertPath != "" {
 		clientCertCAPath = clusterConfig.Configure.Controller.ClientAuthCACertPath
 	}
 
-	ctl.ds.GenerateCNCIWorkload(cnciVCPUs, cnciMem, cnciDisk, adminSSHKey, adminPassword)
+	ctl.ds.GenerateCNCIWorkload(cnciVCPUs, cnciMem, cnciDisk, adminSSHKey)
 
 	database.Logger = gloginterface.CiaoGlogLogger{}
 

--- a/ciao-deploy/cmd/setup.go
+++ b/ciao-deploy/cmd/setup.go
@@ -116,7 +116,6 @@ func init() {
 	setupCmd.Flags().StringVar(&clusterConf.HTTPSCaCertPath, "https-ca-cert", "", "Path to CA certificate for HTTP service")
 	setupCmd.Flags().StringVar(&clusterConf.HTTPSCertPath, "https-cert", "", "Path to certificate for HTTPS service")
 	setupCmd.Flags().StringVar(&clusterConf.AdminSSHKeyPath, "admin-ssh-key", "", "Path to SSH public key for accessing CNCI")
-	setupCmd.Flags().StringVar(&clusterConf.AdminSSHPassword, "admin-password", "", "Password for accessing CNCI")
 	setupCmd.Flags().StringVar(&clusterConf.ComputeNet, "compute-net", hostNetwork, "Network range for compute network")
 	setupCmd.Flags().StringVar(&clusterConf.MgmtNet, "mgmt-net", hostNetwork, "Network range for management network")
 	setupCmd.Flags().StringVar(&clusterConf.ServerIP, "server-ip", hostIP, "IP address nodes can reach this host on")

--- a/ciao-deploy/deploy/setup.go
+++ b/ciao-deploy/deploy/setup.go
@@ -42,7 +42,6 @@ type ClusterConfiguration struct {
 	HTTPSCaCertPath   string
 	HTTPSCertPath     string
 	AdminSSHKeyPath   string
-	AdminSSHPassword  string
 	ComputeNet        string
 	MgmtNet           string
 	ServerIP          string
@@ -97,7 +96,6 @@ func createConfigurationFile(ctx context.Context, clusterConf *ClusterConfigurat
 	config.Configure.Controller.HTTPSKey = clusterConf.HTTPSCertPath
 	config.Configure.Controller.ClientAuthCACertPath = clusterConf.AuthCACertPath
 
-	config.Configure.Controller.AdminPassword = clusterConf.AdminSSHPassword
 	config.Configure.Controller.AdminSSHKey = adminSSHKeyData
 
 	config.Configure.Launcher.ComputeNetwork = []string{clusterConf.ComputeNet}

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -64,7 +64,6 @@ const fullValidConf = `configure:
     cnci_mem: 128
     cnci_disk: 128
     admin_ssh_key: ""
-    admin_password: ""
     client_auth_ca_cert_path: /etc/pki/ciao/auth-CA.pem
   launcher:
     compute_net:

--- a/payloads/configure.go
+++ b/payloads/configure.go
@@ -50,7 +50,6 @@ type ConfigureController struct {
 	CNCIMem              int    `yaml:"cnci_mem"`
 	CNCIDisk             int    `yaml:"cnci_disk"`
 	AdminSSHKey          string `yaml:"admin_ssh_key"`
-	AdminPassword        string `yaml:"admin_password"`
 	ClientAuthCACertPath string `yaml:"client_auth_ca_cert_path"`
 }
 

--- a/testutil/payloads.go
+++ b/testutil/payloads.go
@@ -311,7 +311,6 @@ const ConfigureYaml = `configure:
     cnci_mem: 0
     cnci_disk: 0
     admin_ssh_key: ""
-    admin_password: ""
     client_auth_ca_cert_path: ""
   launcher:
     compute_net:

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -171,7 +171,6 @@ ciao-deploy setup \
 --https-cert="$https_key" \
 --https-ca-cert="$https_cert" \
 --admin-ssh-key="$workload_sshkey".pub \
---admin-password="$test_passwd" \
 --local-launcher \
 --mgmt-net="$ciao_vlan_subnet" --compute-net="$ciao_vlan_subnet" \
 --server-ip="$ciao_vlan_ip" \


### PR DESCRIPTION
Remove admin password for CNCI. The admin can provide an SSH key and get passwordless sudo anyway. This fixes a security issue where not specifying a password would set it to "ciao" and allow access.