### PR TITLE
Revert "ciao-{controller,launcher,scheduler}: log panics to glog"

### DIFF
--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -25,7 +25,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"runtime/debug"
 	"sync"
 	"syscall"
 
@@ -125,13 +124,6 @@ func getNameFromCert(httpsCAcert, httpsKey string) (string, error) {
 }
 
 func main() {
-	defer func() {
-		if r := recover(); r != nil {
-			glog.Errorf("%s", debug.Stack())
-			glog.Flush()
-		}
-	}()
-
 	if *prepare {
 		logger := gloginterface.CiaoGlogLogger{}
 		osprepare.Bootstrap(context.TODO(), logger)

--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -586,12 +586,6 @@ DONE:
 }
 
 func main() {
-	defer func() {
-		if r := recover(); r != nil {
-			glog.Errorf("%s", debug.Stack())
-			glog.Flush()
-		}
-	}()
 
 	flag.Parse()
 

--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"runtime/debug"
 	"runtime/pprof"
 	"sync"
 	"syscall"
@@ -1175,13 +1174,6 @@ func configSchedulerServer() (sched *ssntpSchedulerServer) {
 }
 
 func main() {
-	defer func() {
-		if r := recover(); r != nil {
-			glog.Errorf("%s", debug.Stack())
-			glog.Flush()
-		}
-	}()
-
 	flag.Parse()
 
 	if err := initLogger(); err != nil {


### PR DESCRIPTION
This reverts commit 702b3312fa7b0d3c4b5306ecc8326255eceba173.

Unfortunately this only works on panic()s from the main goroutine which
makes it generally unhelpful. For consistency stop logging any panics to
the glog. As they are reported on stderr they can be found in the
systemd logs.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>