### PR TITLE
ciao-controller: remove duplicate volume creation paths

### DIFF
--- a/ciao-controller/api/api.go
+++ b/ciao-controller/api/api.go
@@ -95,6 +95,7 @@ type RequestedVolume struct {
 	Description string `json:"description,omitempty"`
 	Name        string `json:"name,omitempty"`
 	ImageRef    string `json:"imageRef,omitempty"`
+	Internal    bool   `json:"-"`
 }
 
 // CreateServerRequest contains the details needed to start new instance(s)

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -1235,13 +1235,12 @@ func TestGetStorageForVolume(t *testing.T) {
 	}
 
 	createdVolume, err := ctl.ds.GetBlockDevice(pl.ID)
-
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if len(createdVolume.Name) == 0 {
-		t.Errorf("block device name not set")
+	if createdVolume.State != types.Available {
+		t.Fatal("Expected newly created block device to be available")
 	}
 }
 
@@ -1286,13 +1285,12 @@ func TestGetStorageForImage(t *testing.T) {
 	}
 
 	createdVolume, err := ctl.ds.GetBlockDevice(pl.ID)
-
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if len(createdVolume.Name) == 0 {
-		t.Errorf("block device name not set")
+	if createdVolume.State != types.Available {
+		t.Fatal("Expected newly created block device to be available")
 	}
 }
 


### PR DESCRIPTION
The paths to create volumes for an instance and to create volumes
explicitly duplicated lot of code which this commit consolidates.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>