### PR TITLE
ciao-controller: support same image name for multiple tenants

### DIFF
--- a/_release/bat/workload_bat/workload_bat_test.go
+++ b/_release/bat/workload_bat/workload_bat_test.go
@@ -46,12 +46,18 @@ runcmd:
 `
 
 const vmWorkloadImageName = "ubuntu-server-16.04"
+const vmPublicWorkloadImageName = "clear-linux-latest"
 
-func getWorkloadSource(ctx context.Context, t *testing.T, tenant string) bat.Source {
-	// get the Image ID to use.
+func getWorkloadSource(ctx context.Context, t *testing.T, public bool) bat.Source {
 	source := bat.Source{
 		Type:   "image",
 		Source: vmWorkloadImageName,
+	}
+
+	if public {
+		source.Source = vmPublicWorkloadImageName
+	} else {
+		source.Source = vmWorkloadImageName
 	}
 
 	return source
@@ -66,7 +72,7 @@ func testCreateWorkload(t *testing.T, public bool) {
 
 	// generate ssh test keys?
 
-	source := getWorkloadSource(ctx, t, tenant)
+	source := getWorkloadSource(ctx, t, public)
 
 	// fill out the opt structure for this workload.
 	requirements := bat.WorkloadRequirements{
@@ -171,7 +177,7 @@ func TestCreateWorkloadWithSizedVolume(t *testing.T) {
 	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
 	defer cancelFunc()
 
-	source := getWorkloadSource(ctx, t, tenant)
+	source := getWorkloadSource(ctx, t, false)
 
 	requirements := bat.WorkloadRequirements{
 		VCPUs: 2,
@@ -259,7 +265,7 @@ func TestCreateWorkloadWithSizedVolume(t *testing.T) {
 func testSchedulableWorkloadRequirements(ctx context.Context, t *testing.T, requirements bat.WorkloadRequirements, schedulable bool) {
 	tenant := ""
 
-	source := getWorkloadSource(ctx, t, tenant)
+	source := getWorkloadSource(ctx, t, false)
 
 	disk := bat.Disk{
 		Bootable:  true,

--- a/ciao-controller/image.go
+++ b/ciao-controller/image.go
@@ -205,7 +205,12 @@ func (c *controller) DeleteImage(tenantID, imageID string) error {
 func (c *controller) GetImage(tenantID, imageID string) (types.Image, error) {
 	glog.Infof("Getting Image [%v] from [%v]", imageID, tenantID)
 
-	image, err := c.ds.ResolveImage(imageID)
+	id, err := c.ds.ResolveImage(tenantID, imageID)
+	if err != nil {
+		return types.Image{}, err
+	}
+
+	image, err := c.ds.GetImage(id)
 	if err != nil {
 		return types.Image{}, err
 	}

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -2793,18 +2793,18 @@ func TestResolveImage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	i2, err := ds.ResolveImage(i.Name)
+	id2, err := ds.ResolveImage(tenant.ID, i.Name)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	i3, err := ds.ResolveImage(i.ID)
+	id3, err := ds.ResolveImage(tenant.ID, i.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !reflect.DeepEqual(i2, i3) {
-		t.Fatal("Expected images returned by name and ID resolution equal")
+	if id2 != id3 {
+		t.Fatal("Expected image ID returned by name and ID resolution equal")
 	}
 }
 

--- a/ciao-deploy/deploy/workloads.go
+++ b/ciao-deploy/deploy/workloads.go
@@ -85,8 +85,8 @@ type workloadDetails interface {
 
 var images = []workloadDetails{
 	&baseWorkload{
-		url:       "https://download.fedoraproject.org/pub/fedora/linux/releases/24/CloudImages/x86_64/images/Fedora-Cloud-Base-24-1.2.x86_64.qcow2",
-		imageName: "fedora-cloud-base-24-1.2",
+		url:       "https://download.fedoraproject.org/pub/fedora/linux/releases/27/CloudImages/x86_64/images/Fedora-Cloud-Base-27-1.6.x86_64.qcow2",
+		imageName: "fedora-cloud-base-27-1.6",
 		extra:     true,
 		cloudInit: vmCloudInit,
 		opts: bat.WorkloadOptions{


### PR DESCRIPTION
The original code for implementing image name resolution inadvertently
enforced a restriction of image name uniqueness across the whole cluster
rather than per-tenant. Adopt the same algorithm that instance name
resolution uses so that the uniqueness is only per tenant.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>