### PR TITLE
send cnci refresh command

### DIFF
--- a/ciao-controller/client.go
+++ b/ciao-controller/client.go
@@ -45,6 +45,7 @@ type controllerClient interface {
 	unMapExternalIP(t types.Tenant, m types.MappedIP) error
 	attachVolume(volID string, instanceID string, nodeID string) error
 	ssntpClient() *ssntp.Client
+	CNCIRefresh(cnciID string, cnciList []payloads.CNCINet) error
 }
 
 type ssntpClient struct {
@@ -775,5 +776,25 @@ func (client *ssntpClient) unMapExternalIP(t types.Tenant, m types.MappedIP) err
 	glog.V(1).Info(string(y))
 
 	_, err = client.ssntp.SendCommand(ssntp.ReleasePublicIP, y)
+	return err
+}
+
+func (client *ssntpClient) CNCIRefresh(cnciID string, cnciList []payloads.CNCINet) error {
+	payload := payloads.CommandCNCIRefresh{
+		Command: payloads.CNCIRefreshCommand{
+			CNCIUUID: cnciID,
+			CNCIList: cnciList,
+		},
+	}
+
+	y, err := yaml.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	glog.Infof("Refresh CNCI %s: %v\n", cnciID, cnciList)
+	glog.V(1).Info(string(y))
+
+	_, err = client.ssntp.SendCommand(ssntp.RefreshCNCI, y)
 	return err
 }

--- a/ciao-controller/client_wrapper_test.go
+++ b/ciao-controller/client_wrapper_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/ciao-project/ciao/ciao-controller/types"
+	"github.com/ciao-project/ciao/payloads"
 	"github.com/ciao-project/ciao/ssntp"
 )
 
@@ -271,4 +272,8 @@ func (client *ssntpClientWrapper) sendAndDelEventChan(cmd ssntp.Event) {
 
 func (client *ssntpClientWrapper) RemoveInstance(ID string) {
 	client.realClient.RemoveInstance(ID)
+}
+
+func (client *ssntpClientWrapper) CNCIRefresh(cnciID string, cnciList []payloads.CNCINet) error {
+	return client.realClient.CNCIRefresh(cnciID, cnciList)
 }

--- a/ciao-deploy/cmd/setup.go
+++ b/ciao-deploy/cmd/setup.go
@@ -140,6 +140,7 @@ func init() {
 	setupCmd.Flags().StringVar(&clusterConf.AdminSSHKeyPath, "admin-ssh-key", "", "Path to SSH public key for accessing CNCI")
 	setupCmd.Flags().StringVar(&clusterConf.ComputeNet, "compute-net", hostNetwork, "Network range for compute network")
 	setupCmd.Flags().StringVar(&clusterConf.MgmtNet, "mgmt-net", hostNetwork, "Network range for management network")
+	setupCmd.Flags().StringVar(&clusterConf.CNCINet, "cnci-net", "192.168.128.0", "Host start address for CNCI mgmt network - must be at least /18")
 	setupCmd.Flags().StringVar(&clusterConf.ServerIP, "server-ip", hostIP, "IP address nodes can reach this host on")
 	setupCmd.Flags().StringVar(&clusterConf.ServerHostname, "server-hostname", deploy.HostnameWithFallback(), "Name or FQDN that this host can be reached on")
 	setupCmd.Flags().StringVar(&imageCacheDirectory, "image-cache-directory", deploy.DefaultImageCacheDir(), "Directory to use for caching of downloaded images")

--- a/ciao-deploy/deploy/setup.go
+++ b/ciao-deploy/deploy/setup.go
@@ -44,6 +44,7 @@ type ClusterConfiguration struct {
 	AdminSSHKeyPath   string
 	ComputeNet        string
 	MgmtNet           string
+	CNCINet           string
 	ServerIP          string
 	AuthCACertPath    string
 	AuthAdminCertPath string
@@ -96,6 +97,7 @@ func createConfigurationFile(ctx context.Context, clusterConf *ClusterConfigurat
 	config.Configure.Controller.HTTPSCACert = clusterConf.HTTPSCaCertPath
 	config.Configure.Controller.HTTPSKey = clusterConf.HTTPSCertPath
 	config.Configure.Controller.ClientAuthCACertPath = clusterConf.AuthCACertPath
+	config.Configure.Controller.CNCINet = clusterConf.CNCINet
 
 	config.Configure.Controller.AdminSSHKey = adminSSHKeyData
 

--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -546,6 +546,10 @@ func (sched *ssntpSchedulerServer) getCommandConcentratorUUID(command ssntp.Comm
 		var cmd payloads.CommandReleasePublicIP
 		err := yaml.Unmarshal(payload, &cmd)
 		return cmd.ReleaseIP.ConcentratorUUID, err
+	case ssntp.RefreshCNCI:
+		var cmd payloads.CommandCNCIRefresh
+		err := yaml.Unmarshal(payload, &cmd)
+		return cmd.Command.CNCIUUID, err
 	}
 }
 
@@ -811,6 +815,8 @@ func (sched *ssntpSchedulerServer) CommandForward(controllerUUID string, command
 		fallthrough
 	case ssntp.Restore:
 		dest, instanceUUID = sched.fwdCmdToComputeNode(command, payload)
+	case ssntp.RefreshCNCI:
+		fallthrough
 	case ssntp.AssignPublicIP:
 		fallthrough
 	case ssntp.ReleasePublicIP:
@@ -1123,6 +1129,10 @@ func setSSNTPForwardRules(sched *ssntpSchedulerServer) {
 		},
 		{ // all ReleasePublicIP commands are processed by the Command forwarder
 			Operand:        ssntp.ReleasePublicIP,
+			CommandForward: sched,
+		},
+		{ // all RefreshCNCI commands are processed by the Command forwarder
+			Operand:        ssntp.RefreshCNCI,
 			CommandForward: sched,
 		},
 	}

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -65,6 +65,7 @@ const fullValidConf = `configure:
     cnci_disk: 128
     admin_ssh_key: ""
     client_auth_ca_cert_path: /etc/pki/ciao/auth-CA.pem
+    cnci_net: 10.10.0.0
   launcher:
     compute_net:
     - 192.168.1.0/24
@@ -119,6 +120,7 @@ func fillPayload(conf *payloads.Configure) {
 	conf.Configure.Controller.CNCIMem = 128
 	conf.Configure.Controller.CNCIDisk = 128
 	conf.Configure.Controller.ClientAuthCACertPath = clientAuthCACert
+	conf.Configure.Controller.CNCINet = "10.10.0.0"
 	conf.Configure.Launcher.ComputeNetwork = []string{computeNet}
 	conf.Configure.Launcher.ManagementNetwork = []string{mgmtNet}
 	conf.Configure.Launcher.ChildUser = "ciao"

--- a/networking/ciao-cnci-agent/network.go
+++ b/networking/ciao-cnci-agent/network.go
@@ -409,3 +409,20 @@ func releasePubIP(cmd *payloads.PublicIPCommand) error {
 	err = gFw.PublicIPAccess(libsnnet.FwDisable, prIP, puIP, gCnci.ComputeLink[0].Attrs().Name)
 	return errors.Wrapf(err, "release ip")
 }
+
+func refreshCNCI(cmd *payloads.CNCIRefreshCommand) error {
+	var neighbors []libsnnet.Neighbor
+
+	cncis := cmd.CNCIList
+	for _, c := range cncis {
+		n := libsnnet.Neighbor{
+			PhysicalIP: c.PhysicalIP,
+			Subnet:     c.Subnet,
+			TunnelIP:   c.TunnelIP,
+			TunnelID:   c.TunnelID,
+		}
+		neighbors = append(neighbors, n)
+	}
+
+	return gCnci.UpdateNeighbors(neighbors)
+}

--- a/networking/libsnnet/cn_test.go
+++ b/networking/libsnnet/cn_test.go
@@ -726,7 +726,7 @@ func TestCN_Whitebox(t *testing.T) {
 		remote := concIP
 
 		greAlias := fmt.Sprintf("gre_%s_%s_%s", tenantUUID, subnetUUID, concUUID)
-		gre, _ := newGreTunEP(greAlias, local, remote, subnetKey)
+		gre, _ := newGreTapEP(greAlias, local, remote, subnetKey)
 
 		assert.Nil(gre.create())
 		defer func() { _ = gre.destroy() }()

--- a/networking/libsnnet/cnci.go
+++ b/networking/libsnnet/cnci.go
@@ -377,7 +377,7 @@ func createCnciBridge(bridge *Bridge, brInfo *bridgeInfo, tenant string, subnet 
 	return err
 }
 
-func createCnciTunnel(gre *GreTunEP) (err error) {
+func createCnciTunnel(gre *GreTapEP) (err error) {
 	if err = gre.create(); err != nil {
 		return err
 	}
@@ -405,7 +405,7 @@ func checkInputParams(subnet net.IPNet, subnetKey int, cnIP net.IP) error {
 //If the function returns error the bridgeName can be ignored
 //If the function does not return error and has a valid bridge name
 //then the subnet has been found and no further processing is needed
-func (cnci *Cnci) addSubnetToTopology(bridge *Bridge, gre *GreTunEP, brInfo **bridgeInfo) (brExists bool,
+func (cnci *Cnci) addSubnetToTopology(bridge *Bridge, gre *GreTapEP, brInfo **bridgeInfo) (brExists bool,
 	greExists bool, bLink *linkInfo, gLink *linkInfo, err error) {
 	err = nil
 
@@ -477,7 +477,7 @@ func (cnci *Cnci) AddRemoteSubnet(subnet net.IPNet, subnetKey int, cnIP net.IP) 
 		return "", err
 	}
 
-	gre, err := newGreTunEP(genGreAlias(subnet, cnIP), cnci.ComputeAddr[0].IPNet.IP, cnIP, uint32(subnetKey))
+	gre, err := newGreTapEP(genGreAlias(subnet, cnIP), cnci.ComputeAddr[0].IPNet.IP, cnIP, uint32(subnetKey))
 	if err != nil {
 		return "", err
 	}
@@ -542,7 +542,7 @@ func (cnci *Cnci) DelRemoteSubnet(subnet net.IPNet, subnetKey int, cnIP net.IP) 
 
 	bridgeID := genBridgeAlias(subnet)
 
-	gre, err := newGreTunEP(genGreAlias(subnet, cnIP),
+	gre, err := newGreTapEP(genGreAlias(subnet, cnIP),
 		cnci.ComputeAddr[0].IPNet.IP,
 		cnIP, uint32(subnetKey))
 

--- a/networking/libsnnet/cnci.go
+++ b/networking/libsnnet/cnci.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/vishvananda/netlink"
 )
 
@@ -83,6 +84,14 @@ func reinitTopology(topology *cnciTopology) {
 type bridgeInfo struct {
 	tunnels int
 	*Dnsmasq
+}
+
+// Neighbor contains information about other CNCIs for this tenant.
+type Neighbor struct {
+	PhysicalIP string
+	Subnet     string
+	TunnelIP   string
+	TunnelID   uint32
 }
 
 func enableForwarding() error {
@@ -460,6 +469,209 @@ func (cnci *Cnci) addSubnetToTopology(bridge *Bridge, gre *GreTapEP, brInfo **br
 	cnci.topology.Unlock()
 	//End CS
 	return
+}
+
+// confirm that the gre tunnel device exists. If not, create
+// it. Confirm that the correct address is associated with
+// the tunnel device.
+func (cnci *Cnci) confirmTunnel(n Neighbor) (*GreTunEP, error) {
+	IP := net.ParseIP(n.PhysicalIP)
+	if IP == nil {
+		return nil, fmt.Errorf("Unable to parse local physical IP address")
+	}
+
+	tun, err := newGreTunEP("cncitun", IP, n.TunnelID)
+	if err != nil {
+		return nil, err
+	}
+
+	// see if the device already exists
+	err = tun.getDevice()
+	if err != nil {
+		if err = tun.create(); err != nil {
+			return nil, err
+		}
+		if err = tun.enable(); err != nil {
+			return nil, err
+		}
+	}
+
+	// see if my address already exists
+	addrs, err := netlink.AddrList(tun.Link, netlink.FAMILY_V4)
+	if err != nil {
+		return nil, err
+	}
+
+	// XXX: hardcode netmask to 18 for now.
+	addr, err := netlink.ParseAddr(fmt.Sprintf("%s/%d", n.TunnelIP, 18))
+	if err != nil {
+		return nil, err
+	}
+
+	var added bool
+	for _, a := range addrs {
+		if addr.Equal(a) {
+			added = true
+		} else {
+			// we should remove this addr.
+			// we can do this because there should
+			// be only one.
+			err = netlink.AddrDel(tun.Link, &a)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	if !added {
+		err = netlink.AddrAdd(tun.Link, addr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return tun, nil
+}
+
+func neighborEqual(a netlink.Neigh, b netlink.Neigh) (equal bool) {
+	if a.IP.Equal(b.IP) && a.LLIPAddr.Equal(b.LLIPAddr) {
+		return true
+	}
+	return false
+}
+
+// make sure that the neighbor entries are correct, as well as the
+// route entry for the neighbor.
+func (cnci *Cnci) confirmNeighbors(tun *GreTunEP, n Neighbor, neighs []netlink.Neigh) (netlink.Neigh, error) {
+	neigh := netlink.Neigh{
+		IP:        net.ParseIP(n.TunnelIP),
+		LLIPAddr:  net.ParseIP(n.PhysicalIP),
+		LinkIndex: tun.Link.Index,
+		State:     netlink.NUD_PERMANENT,
+	}
+
+	var exists bool
+	// see if this already exists
+	for _, neighbor := range neighs {
+		exists = neighborEqual(neighbor, neigh)
+		if exists {
+			break
+		}
+	}
+
+	if !exists {
+		err := netlink.NeighAdd(&neigh)
+		if err != nil {
+			return neigh, err
+		}
+
+		dst := net.IPNet{
+			IP:   net.ParseIP(n.TunnelIP),
+			Mask: net.CIDRMask(32, 32),
+		}
+
+		route := netlink.Route{
+			LinkIndex: tun.Link.Index,
+			Dst:       &dst,
+		}
+		err = netlink.RouteAdd(&route)
+		if err != nil {
+			return neigh, err
+		}
+
+		_, IPnet, err := net.ParseCIDR(n.Subnet)
+		if err != nil {
+			return neigh, err
+		}
+
+		route = netlink.Route{
+			LinkIndex: tun.Link.Index,
+			Dst:       IPnet,
+			Gw:        net.ParseIP(n.TunnelIP),
+		}
+
+		err = netlink.RouteAdd(&route)
+		if err != nil {
+			return neigh, err
+		}
+	}
+	return neigh, nil
+}
+
+func (cnci *Cnci) confirmRoutes(tun *GreTunEP, updated []netlink.Neigh, old []netlink.Neigh) error {
+	routes, err := netlink.RouteList(tun.Link, netlink.FAMILY_V4)
+	if err != nil {
+		return err
+	}
+
+	for _, n := range old {
+		var found bool
+		for _, new := range updated {
+			found = neighborEqual(n, new)
+			if found {
+				break
+			}
+		}
+
+		if !found {
+			err := netlink.NeighDel(&n)
+			if err != nil {
+				glog.Warningf("Unable to delete stale neighbor: (%v)\n", err)
+				// keep going.
+			}
+
+			// remove routes.
+			for _, r := range routes {
+				if r.Dst.IP.Equal(n.IP) || r.Gw.Equal(n.IP) {
+					err = netlink.RouteDel(&r)
+					if err != nil {
+						glog.Warningf("Unable to delete stale route (%v)\n", err)
+						// keep going.
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// UpdateNeighbors will create a point to multipoint gre tunnel between
+// all the CNCIs for this tenant.
+func (cnci *Cnci) UpdateNeighbors(neighbors []Neighbor) error {
+	var tun *GreTunEP
+	var err error
+
+	// this must be done first
+	for _, n := range neighbors {
+		if n.PhysicalIP == cnci.ComputeAddr[0].IPNet.IP.String() {
+			tun, err = cnci.confirmTunnel(n)
+			if err != nil {
+				return err
+			}
+			break
+		}
+	}
+
+	neighs, err := netlink.NeighList(tun.Link.Index, netlink.FAMILY_V4)
+	if err != nil {
+		return err
+	}
+
+	var updated []netlink.Neigh
+	for _, n := range neighbors {
+		if n.PhysicalIP == cnci.ComputeAddr[0].IPNet.IP.String() {
+			continue
+		}
+
+		neigh, err := cnci.confirmNeighbors(tun, n, neighs)
+		if err != nil {
+			return err
+		}
+
+		updated = append(updated, neigh)
+	}
+
+	// clean up any routes neighbors that need removing.
+	return cnci.confirmRoutes(tun, updated, neighs)
 }
 
 //AddRemoteSubnet attaches a remote subnet to a local bridge on the CNCI

--- a/networking/libsnnet/cnci_test.go
+++ b/networking/libsnnet/cnci_test.go
@@ -167,7 +167,7 @@ func TestCNCI_Internal(t *testing.T) {
 	remote := cnIP
 	key := subnetKey
 
-	gre, _ := newGreTunEP(greAlias, local, remote, key)
+	gre, _ := newGreTapEP(greAlias, local, remote, key)
 
 	assert.Nil(gre.create())
 	defer func() { _ = gre.destroy() }()

--- a/networking/libsnnet/fuzz_test.go
+++ b/networking/libsnnet/fuzz_test.go
@@ -142,7 +142,7 @@ func TestNwPrimitives_Fuzz(t *testing.T) {
 		_ = bridge.Destroy()
 	}
 
-	gre := &GreTunEP{}
+	gre := &GreTapEP{}
 	_ = gre.create()
 	_ = gre.enable()
 	_ = gre.disable()
@@ -153,7 +153,7 @@ func TestNwPrimitives_Fuzz(t *testing.T) {
 		f.Fuzz(&gre.LocalIP)
 		f.Fuzz(&gre.RemoteIP)
 		f.Fuzz(&gre.Key)
-		gre, _ = newGreTunEP(gre.GlobalID, gre.LocalIP, gre.RemoteIP, gre.Key)
+		gre, _ = newGreTapEP(gre.GlobalID, gre.LocalIP, gre.RemoteIP, gre.Key)
 		_ = gre.create()
 		_ = gre.enable()
 		_ = gre.disable()

--- a/networking/libsnnet/gre.go
+++ b/networking/libsnnet/gre.go
@@ -24,8 +24,8 @@ import (
 
 // NewGreTunEP is used to initialize the GRE tunnel properties
 // This has to be called prior to Create() or GetDevice()
-func newGreTunEP(id string, localIP net.IP, remoteIP net.IP, key uint32) (*GreTunEP, error) {
-	gre := &GreTunEP{}
+func newGreTapEP(id string, localIP net.IP, remoteIP net.IP, key uint32) (*GreTapEP, error) {
+	gre := &GreTapEP{}
 	gre.Link = &netlink.Gretap{}
 	gre.GlobalID = id
 	gre.LocalIP = localIP
@@ -35,7 +35,7 @@ func newGreTunEP(id string, localIP net.IP, remoteIP net.IP, key uint32) (*GreTu
 }
 
 // GetDevice associates the tunnel with an existing GRE tunnel end point
-func (g *GreTunEP) getDevice() error {
+func (g *GreTapEP) getDevice() error {
 
 	if g.GlobalID == "" {
 		return netError(g, "get device unnamed gretap device")
@@ -64,7 +64,7 @@ func (g *GreTunEP) getDevice() error {
 }
 
 // Create instantiates a tunnel
-func (g *GreTunEP) create() error {
+func (g *GreTapEP) create() error {
 	var err error
 
 	if g.GlobalID == "" || g.Key == 0 {
@@ -116,7 +116,7 @@ func (g *GreTunEP) create() error {
 }
 
 // Destroy an existing Tunnel
-func (g *GreTunEP) destroy() error {
+func (g *GreTapEP) destroy() error {
 
 	if g.Link == nil || g.Link.Index == 0 {
 		return netError(g, "destroy invalid gre link: %v", g)
@@ -130,7 +130,7 @@ func (g *GreTunEP) destroy() error {
 }
 
 // Enable the GreTunnel
-func (g *GreTunEP) enable() error {
+func (g *GreTapEP) enable() error {
 
 	if g.Link == nil || g.Link.Index == 0 {
 		return netError(g, "enable invalid gre link: %v", g)
@@ -145,7 +145,7 @@ func (g *GreTunEP) enable() error {
 }
 
 // Disable the Tunnel
-func (g *GreTunEP) disable() error {
+func (g *GreTapEP) disable() error {
 	if g.Link == nil || g.Link.Index == 0 {
 		return netError(g, "disable invalid gre link: %v", g)
 	}
@@ -156,7 +156,7 @@ func (g *GreTunEP) disable() error {
 	return nil
 }
 
-func (g *GreTunEP) setAlias(alias string) error {
+func (g *GreTapEP) setAlias(alias string) error {
 	if g.Link == nil || g.Link.Index == 0 {
 		return netError(g, "set alias invalid gre link: %v", g)
 	}
@@ -169,7 +169,7 @@ func (g *GreTunEP) setAlias(alias string) error {
 }
 
 // Attach the GRE tunnel to a device/bridge/switch
-func (g *GreTunEP) attach(dev interface{}) error {
+func (g *GreTapEP) attach(dev interface{}) error {
 
 	if g.Link == nil || g.Link.Index == 0 {
 		return netError(g, "attach gre tunnel unnitialized")
@@ -193,7 +193,7 @@ func (g *GreTunEP) attach(dev interface{}) error {
 }
 
 // Detach the GRE Tunnel from the device/bridge it is attached to
-func (g *GreTunEP) detach(dev interface{}) error {
+func (g *GreTapEP) detach(dev interface{}) error {
 	if g.Link == nil || g.Link.Index == 0 {
 		return netError(g, "detach invalid gre link: %v", g)
 	}

--- a/networking/libsnnet/gre_test.go
+++ b/networking/libsnnet/gre_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func performGreOps(shouldPass bool, assert *assert.Assertions, gre *GreTunEP) {
+func performGreOps(shouldPass bool, assert *assert.Assertions, gre *GreTapEP) {
 	a := assert.Nil
 	if !shouldPass {
 		a = assert.NotNil
@@ -49,7 +49,7 @@ func TestGre_Basic(t *testing.T) {
 	remote := local
 	key := uint32(0xF)
 
-	gre, err := newGreTunEP(id, local, remote, key)
+	gre, err := newGreTapEP(id, local, remote, key)
 	assert.Nil(err)
 
 	assert.Nil(gre.create())
@@ -71,7 +71,7 @@ func TestGre_Bridge(t *testing.T) {
 	remote := local
 	key := uint32(0xF)
 
-	gre, err := newGreTunEP(id, local, remote, key)
+	gre, err := newGreTapEP(id, local, remote, key)
 	assert.Nil(err)
 	bridge, err := NewBridge("testbridge")
 	assert.Nil(err)
@@ -104,9 +104,9 @@ func TestGre_Negative(t *testing.T) {
 	remote := local
 	key := uint32(0xF)
 
-	gre, err := newGreTunEP(id, local, remote, key)
+	gre, err := newGreTapEP(id, local, remote, key)
 	assert.Nil(err)
-	greDupl, err := newGreTunEP(id, local, remote, key)
+	greDupl, err := newGreTapEP(id, local, remote, key)
 	assert.Nil(err)
 
 	assert.Nil(gre.create())

--- a/networking/libsnnet/gretun.go
+++ b/networking/libsnnet/gretun.go
@@ -1,0 +1,156 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package libsnnet
+
+import (
+	"net"
+
+	"github.com/vishvananda/netlink"
+)
+
+// NewGreTunEP is used to initialize the GRE tunnel properties
+// This has to be called prior to Create() or GetDevice()
+func newGreTunEP(id string, localIP net.IP, key uint32) (*GreTunEP, error) {
+	gre := &GreTunEP{}
+	gre.Link = &netlink.Gretun{}
+	gre.GlobalID = id
+	gre.LocalIP = localIP
+	gre.Key = key
+	return gre, nil
+}
+
+// GetDevice associates the tunnel with an existing GRE tunnel end point
+func (g *GreTunEP) getDevice() error {
+
+	if g.GlobalID == "" {
+		return netError(g, "get device unnamed gretap device")
+	}
+
+	link, err := netlink.LinkByAlias(g.GlobalID)
+	if err != nil {
+		return netError(g, "get device interface does not exist: %v %v", g.GlobalID, err)
+	}
+
+	gl, ok := link.(*netlink.Gretun)
+	if !ok {
+		return netError(g, "get device incorrect interface type %v %v", g.GlobalID, link.Type())
+	}
+	g.Link = gl
+	g.LinkName = gl.Name
+	g.LocalIP = gl.Local
+	if gl.IKey == gl.OKey {
+		g.Key = gl.IKey
+	} else {
+		return netError(g, "get device incorrect params IKey != OKey %v %v", g.GlobalID, gl)
+	}
+
+	return nil
+}
+
+// Create instantiates a tunnel
+func (g *GreTunEP) create() error {
+	var err error
+
+	if g.GlobalID == "" || g.Key == 0 {
+		return netError(g, "create cannot create an unnamed gretap device")
+	}
+
+	attrs := netlink.NewLinkAttrs()
+	attrs.Name = g.GlobalID
+
+	gretap := &netlink.Gretun{LinkAttrs: attrs,
+		IKey:     g.Key,
+		OKey:     g.Key,
+		Local:    g.LocalIP,
+		PMtuDisc: 1,
+	}
+
+	if err := netlink.LinkAdd(gretap); err != nil {
+		return netError(g, "create link add %v %v", g.GlobalID, err)
+	}
+
+	link, err := netlink.LinkByName(g.GlobalID)
+	if err != nil {
+		return netError(g, "create link by name %v %v", g.GlobalID, err)
+	}
+
+	gl, ok := link.(*netlink.Gretun)
+	if !ok {
+		return netError(g, "create incorrect interface type %v, %v", g.GlobalID, link.Type())
+	}
+	g.Link = gl
+
+	if err := g.setAlias(g.GlobalID); err != nil {
+		_ = g.destroy()
+		return netError(g, "create link set alias %v %v", g.GlobalID, err)
+	}
+
+	return nil
+}
+
+// Destroy an existing Tunnel
+func (g *GreTunEP) destroy() error {
+
+	if g.Link == nil || g.Link.Index == 0 {
+		return netError(g, "destroy invalid gre link: %v", g)
+	}
+
+	if err := netlink.LinkDel(g.Link); err != nil {
+		return netError(g, "destroy link del %v", err)
+	}
+
+	return nil
+}
+
+// Enable the GreTunnel
+func (g *GreTunEP) enable() error {
+
+	if g.Link == nil || g.Link.Index == 0 {
+		return netError(g, "enable invalid gre link: %v", g)
+	}
+
+	if err := netlink.LinkSetUp(g.Link); err != nil {
+		return netError(g, "enable link enable %v", err)
+	}
+
+	return nil
+
+}
+
+// Disable the Tunnel
+func (g *GreTunEP) disable() error {
+	if g.Link == nil || g.Link.Index == 0 {
+		return netError(g, "disable invalid gre link: %v", g)
+	}
+
+	if err := netlink.LinkSetDown(g.Link); err != nil {
+		return netError(g, "disable link disable %v", err)
+	}
+	return nil
+}
+
+func (g *GreTunEP) setAlias(alias string) error {
+	if g.Link == nil || g.Link.Index == 0 {
+		return netError(g, "set alias invalid gre link: %v", g)
+	}
+
+	if err := netlink.LinkSetAlias(g.Link, alias); err != nil {
+		return netError(g, "set alias link set alias %v %v", alias, err)
+	}
+
+	return nil
+}

--- a/networking/libsnnet/internal_test.go
+++ b/networking/libsnnet/internal_test.go
@@ -65,7 +65,7 @@ func TestCN_dbRebuild(t *testing.T) {
 		remote := vnicCfg.ConcIP
 		subnetKey := vnicCfg.SubnetKey
 
-		gre, _ := newGreTunEP(greAlias, local, remote, uint32(subnetKey))
+		gre, _ := newGreTapEP(greAlias, local, remote, uint32(subnetKey))
 
 		assert.Nil(gre.create())
 		defer func() { _ = gre.destroy() }()

--- a/networking/libsnnet/network.go
+++ b/networking/libsnnet/network.go
@@ -189,3 +189,14 @@ type GreTapEP struct {
 	CNCIId   string // UUID of the CNCI
 	CNId     string // UUID of the CN
 }
+
+// GreTunEP ciao GRE Tun device representation
+// This represents one end of a GRE point to multipoint tunnel
+type GreTunEP struct {
+	Attrs
+	Link    *netlink.Gretun
+	Key     uint32
+	LocalIP net.IP
+	CNCIId  string // UUID of the CNCI
+	CNId    string // UUID of the CN
+}

--- a/networking/libsnnet/network.go
+++ b/networking/libsnnet/network.go
@@ -34,7 +34,7 @@ func netError(dev interface{}, format string, args ...interface{}) error {
 		return fmt.Errorf("vnic error: "+format, args...)
 	case CnciVnic, *CnciVnic:
 		return fmt.Errorf("cncivnic error: "+format, args...)
-	case GreTunEP, *GreTunEP:
+	case GreTapEP, *GreTapEP:
 		return fmt.Errorf("gre error: "+format, args...)
 	}
 	return fmt.Errorf("network error: "+format, args...)
@@ -178,9 +178,9 @@ type CnciVnic struct {
 	Link *netlink.Macvtap
 }
 
-// GreTunEP ciao GRE Tunnel representation
+// GreTapEP ciao GRE Tap device representation
 // This represents one end of the tunnel
-type GreTunEP struct {
+type GreTapEP struct {
 	Attrs
 	Link     *netlink.Gretap
 	Key      uint32

--- a/networking/libsnnet/utils.go
+++ b/networking/libsnnet/utils.go
@@ -97,7 +97,7 @@ func getPrefix(device interface{}) (string, error) {
 		case TenantContainer:
 			prefix = prefixVnicHost
 		}
-	case *GreTunEP:
+	case *GreTapEP:
 		prefix = prefixGretap
 	case *CnciVnic:
 		prefix = prefixCnciVnic

--- a/payloads/concentratorinstancerefresh.go
+++ b/payloads/concentratorinstancerefresh.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package payloads
+
+// CNCINet contains information about CNCI network interfaces.
+type CNCINet struct {
+	PhysicalIP string `yaml:"physical_ip"`
+	Subnet     string `yaml:"subnet"`
+	TunnelIP   string `yaml:"tunnel_ip"`
+	TunnelID   uint32 `yaml:"tunnel_id"`
+}
+
+// CNCIRefreshCommand contains information on where to send
+// the updated concentrator instance list.
+type CNCIRefreshCommand struct {
+	CNCIUUID string    `yaml:"cnci_uuid"`
+	CNCIList []CNCINet `yaml:"cncis"`
+}
+
+// CommandCNCIRefresh represents the unmarshalled version of the
+// contents of an SSNTP ssntp.ConcentratorInstanceRefresh command. This command
+// is sent by the controller to the cnci-agent when new cncis are added or an
+// existing cnci is modified.
+type CommandCNCIRefresh struct {
+	Command CNCIRefreshCommand `yaml:"cnci_refresh"`
+}

--- a/payloads/concentratorinstancerefresh_test.go
+++ b/payloads/concentratorinstancerefresh_test.go
@@ -1,0 +1,82 @@
+/*
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package payloads_test
+
+import (
+	"testing"
+
+	. "github.com/ciao-project/ciao/payloads"
+	"github.com/ciao-project/ciao/testutil"
+	"gopkg.in/yaml.v2"
+)
+
+func TestConcentratorRefreshUnmarshal(t *testing.T) {
+	var cnciRefresh CommandCNCIRefresh
+
+	err := yaml.Unmarshal([]byte(testutil.CNCIRefreshYaml), &cnciRefresh)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if cnciRefresh.Command.CNCIUUID != testutil.CNCIUUID {
+		t.Errorf("Incorrect CNCI UUID [%s]", cnciRefresh.Command.CNCIUUID)
+	}
+
+	if len(cnciRefresh.Command.CNCIList) != 1 {
+		t.Errorf("Incorrect length of CNCI list [%d]", len(cnciRefresh.Command.CNCIList))
+	}
+
+	newCNCI := cnciRefresh.Command.CNCIList[0]
+
+	if newCNCI.PhysicalIP != "10.10.10.1" {
+		t.Errorf("Wrong PhysicalIP field [%s]", newCNCI.PhysicalIP)
+	}
+
+	if newCNCI.Subnet != "172.16.0.0/24" {
+		t.Errorf("Wrong subnet field [%s]", newCNCI.Subnet)
+	}
+
+	if newCNCI.TunnelIP != "192.168.0.0" {
+		t.Errorf("Wrong Tunnel IP field [%s]", newCNCI.TunnelIP)
+	}
+
+	if newCNCI.TunnelID != testutil.CNCITunnelID {
+		t.Errorf("Wrong Tunnel ID field [%d]", newCNCI.TunnelID)
+	}
+}
+
+func TestConcentratorRefreshMarshal(t *testing.T) {
+	var cnciRefresh CommandCNCIRefresh
+	var newCNCI CNCINet
+
+	newCNCI.PhysicalIP = "10.10.10.1"
+	newCNCI.Subnet = "172.16.0.0/24"
+	newCNCI.TunnelIP = "192.168.0.0"
+	newCNCI.TunnelID = testutil.CNCITunnelID
+
+	cnciRefresh.Command.CNCIList = append(cnciRefresh.Command.CNCIList, newCNCI)
+	cnciRefresh.Command.CNCIUUID = testutil.CNCIUUID
+
+	y, err := yaml.Marshal(&cnciRefresh)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if string(y) != testutil.CNCIRefreshYaml {
+		t.Errorf("ConcentratorInstanceRefresh marshalling failed\n[%s]\n vs\n[%s]", string(y), testutil.CNCIRefreshYaml)
+	}
+}

--- a/payloads/configure.go
+++ b/payloads/configure.go
@@ -51,6 +51,7 @@ type ConfigureController struct {
 	CNCIDisk             int    `yaml:"cnci_disk"`
 	AdminSSHKey          string `yaml:"admin_ssh_key"`
 	ClientAuthCACertPath string `yaml:"client_auth_ca_cert_path"`
+	CNCINet              string `yaml:"cnci_net"`
 }
 
 // ConfigureLauncher contains the unmarshalled configurations for the
@@ -92,4 +93,5 @@ func (conf *Configure) InitDefaults() {
 	conf.Configure.Controller.CNCIDisk = 2048
 	conf.Configure.Controller.CNCIMem = 2048
 	conf.Configure.Controller.CNCIVcpus = 4
+	conf.Configure.Controller.CNCINet = "192.168.0.0"
 }

--- a/payloads/configure_test.go
+++ b/payloads/configure_test.go
@@ -60,6 +60,7 @@ func TestConfigureMarshal(t *testing.T) {
 	cfg.Configure.Controller.CiaoPort = p
 	cfg.Configure.Controller.HTTPSCACert = testutil.HTTPSCACert
 	cfg.Configure.Controller.HTTPSKey = testutil.HTTPSKey
+	cfg.Configure.Controller.CNCINet = testutil.CNCINet
 
 	cfg.Configure.Storage.CephID = testutil.ManagementID
 

--- a/ssntp/ssntp.go
+++ b/ssntp/ssntp.go
@@ -42,7 +42,7 @@ type Type uint8
 
 // Command is the SSNTP Command operand.
 // It can be CONNECT, START, STOP, STATS, EVACUATE, DELETE, RESTART,
-// AssignPublicIP, ReleasePublicIP, CONFIGURE or AttachVolume.
+// AssignPublicIP, ReleasePublicIP, CONFIGURE, AttachVolume or RefreshCNCI.
 type Command uint8
 
 // Status is the SSNTP Status operand.
@@ -228,6 +228,11 @@ const (
 	//	|       |       | (0x0) |  (0x4)  |                 |                             |
 	//	+---------------------------------------------------------------------------------+
 	Restore
+
+	// RefreshCNCI is used to ask a CNCI agent to update it's CNCI
+	// tunnel information.
+	// The payload for this command contains the UIID of the CNCI to refresh.
+	RefreshCNCI
 )
 
 const (
@@ -578,6 +583,8 @@ func (command Command) String() string {
 		return "Attach storage volume"
 	case Restore:
 		return "Restore"
+	case RefreshCNCI:
+		return "Refresh CNCI List"
 	}
 
 	return ""

--- a/testutil/payloads.go
+++ b/testutil/payloads.go
@@ -16,13 +16,15 @@
 
 package testutil
 
+import "fmt"
 import "github.com/ciao-project/ciao/payloads"
+import "hash/crc32"
 
 // AgentIP is a test agent IP address
 const AgentIP = "10.2.3.4"
 
 //TenantSubnet is a test tenant subnet
-const TenantSubnet = "10.2.0.0/16"
+const TenantSubnet = "172.16.0.0/16"
 
 // SubnetKey is a test tenant subnet key
 const SubnetKey = "8"
@@ -31,7 +33,7 @@ const SubnetKey = "8"
 const InstancePublicIP = "10.1.2.3"
 
 // InstancePrivateIP is a test instance private IP
-const InstancePrivateIP = "192.168.1.2"
+const InstancePrivateIP = "172.16.0.2"
 
 // VNICMAC is a test instance VNIC MAC address
 const VNICMAC = "aa:bb:cc:01:02:03"
@@ -228,6 +230,23 @@ const EvacuateYaml = `evacuate:
 // RestoreYaml is a sample node Restore ssntp.Command payload for test cases
 const RestoreYaml = `restore:
   workload_agent_uuid: ` + AgentUUID + `
+`
+
+// CNCITunnelID is a gre tunnel ID derived from the tenant UUID
+var CNCITunnelID = crc32.ChecksumIEEE([]byte(TenantUUID))
+
+// CNCITunnelIDstr is the string representation of the CNCITunnelID
+var CNCITunnelIDstr = fmt.Sprint(CNCITunnelID)
+
+// CNCIRefreshYaml is a sample ConcentratorInstanceRefresh ssntp.Event payload
+// for test cases
+var CNCIRefreshYaml = `cnci_refresh:
+  cnci_uuid: ` + CNCIUUID + `
+  cncis:
+  - physical_ip: 10.10.10.1
+    subnet: 172.16.0.0/24
+    tunnel_ip: 192.168.0.0
+    tunnel_id: ` + CNCITunnelIDstr + `
 `
 
 // CNCIAddedYaml is a sample ConcentratorInstanceAdded ssntp.Event payload for test cases

--- a/testutil/payloads.go
+++ b/testutil/payloads.go
@@ -60,6 +60,9 @@ const ComputeNet = "192.168.1.110"
 // MgmtNet is a test management network
 const MgmtNet = "192.168.1.111"
 
+// CNCINet is a test CNCI network
+const CNCINet = "10.10.0.0"
+
 // ManagementID is a test identifier for a Ceph ID
 const ManagementID = "ciao"
 
@@ -312,6 +315,7 @@ const ConfigureYaml = `configure:
     cnci_disk: 0
     admin_ssh_key: ""
     client_auth_ca_cert_path: ""
+    cnci_net: 10.10.0.0
   launcher:
     compute_net:
     - ` + ComputeNet + `


### PR DESCRIPTION
This PR implements the remainder of the support for per subnet CNCIs. Each tenant will now have a set of CNCIs, one per subnet. When a new CNCI is added or removed, as indicated by a ConcentratorInstanceAdded event, the controller will send each CNCI a list of the current CNCIs for that tenant. Each CNCI will have an IP allocated to it which will become a GRE tunnel endpoint. Each CNCI will create a point to multipoint GRE tunnel to direct traffic to the appropriate CNCI as necessary.

