### PR TITLE
Fix kubicle

### DIFF
--- a/ciao-deploy/deploy/setup.go
+++ b/ciao-deploy/deploy/setup.go
@@ -49,6 +49,7 @@ type ClusterConfiguration struct {
 	AuthAdminCertPath string
 	ServerHostname    string
 	DisableLimits     bool
+	CNCISize          string
 }
 
 type unitFileConf struct {
@@ -106,6 +107,18 @@ func createConfigurationFile(ctx context.Context, clusterConf *ClusterConfigurat
 	config.Configure.Launcher.DiskLimit = false
 	config.Configure.Launcher.MemoryLimit = !clusterConf.DisableLimits
 	config.Configure.Launcher.ChildUser = ciaoUser
+
+	switch clusterConf.CNCISize {
+	case "tiny":
+		config.Configure.Controller.CNCIVcpus = 1
+		config.Configure.Controller.CNCIMem = 128
+	case "medium":
+		config.Configure.Controller.CNCIVcpus = 2
+		config.Configure.Controller.CNCIMem = 1024
+	case "large":
+		config.Configure.Controller.CNCIVcpus = 4
+		config.Configure.Controller.CNCIMem = 2048
+	}
 
 	data, err := yaml.Marshal(config)
 	if err != nil {

--- a/k8s/kubicle/cloudinit.go
+++ b/k8s/kubicle/cloudinit.go
@@ -90,10 +90,7 @@ const udMasterTemplate = `
  - {{template "PROXIES" .}}no_proxy=` + "`hostname -i`" + ` kubeadm init --pod-network-cidr 10.244.0.0/16 --token {{.Token}} {{if len .ExternalIP}}--apiserver-cert-extra-sans={{.ExternalIP}}{{end}}
  - cp /etc/kubernetes/admin.conf /home/{{.User}}/
  - chown {{.User}}:{{.User}} /home/{{.User}}/admin.conf
- - {{template "PROXIES" .}}wget https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel-rbac.yml
- - KUBECONFIG=/home/{{.User}}/admin.conf kubectl create -f kube-flannel-rbac.yml
- - {{template "PROXIES" .}}wget https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
- - KUBECONFIG=/home/{{.User}}/admin.conf kubectl create --namespace kube-system -f kube-flannel.yml
+ - {{template "PROXIES" .}}no_proxy=` + "`hostname -i`" + ` KUBECONFIG=/home/{{.User}}/admin.conf kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/v0.9.1/Documentation/kube-flannel.yml
  - if [ $? -eq 0 ] ; then cat /home/{{.User}}/admin.conf | sed -E 's/\/\/[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/\/\/{{.ExternalIP}}/' | curl -T - {{.PhoneHomeIP}}:9000/success ; else cat /var/log/cloud-init-output.log | curl -T - {{.PhoneHomeIP}}:9000/failure; fi
 ...
 `

--- a/k8s/kubicle/kubicle.go
+++ b/k8s/kubicle/kubicle.go
@@ -100,7 +100,7 @@ func createFlags() (*options, error) {
 			diskGiB: 10,
 		},
 		workers:    1,
-		k8sVersion: "1.6.7",
+		k8sVersion: "1.7.11",
 	}
 
 	opts.user = os.Getenv("USER")

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -175,7 +175,8 @@ ciao-deploy setup \
 --mgmt-net="$ciao_vlan_subnet" --compute-net="$ciao_vlan_subnet" \
 --server-ip="$ciao_vlan_ip" \
 --ceph-id="ciao" \
---image-cache-directory="$ciao_bin"
+--image-cache-directory="$ciao_bin" \
+--cnci="tiny"
 ciao-deploy auth create testuser
 
 # Make configuration.yaml world readable otherwise storage tests will be skipped.


### PR DESCRIPTION
This PR fixes kubicle which had been broken by two separate issues:

1. Kubicle was not working in SingleVM with the recommended ccloudVM size of 6GB as the CNCI was consuming too much memory (2GBs instead of 128MB).  This issue has been fixed by adding a new option, --cnci, to ciao-deploy allowing users some control of the resource consumption of CNCIs.
2. The installation instructions for flannel have changed.  The old instructions no longer worked.  This meant that kubicle failed as the master node did not complete its setup correctly.

This commit also bumps up the default version of kubernetes installed by kubicle to 1.7.11

