### PR TITLE
networking: Enable ssh for the last instance in a subnet

### DIFF
--- a/networking/ciao-cnci-agent/network.go
+++ b/networking/ciao-cnci-agent/network.go
@@ -128,7 +128,7 @@ func genIPsInSubnet(subnet net.IPNet) []net.IP {
 	if bits != 32 || ones > 30 || ones == 0 {
 		return nil
 	}
-	subnetSize := ^(^0 << uint32(32-ones))
+	subnetSize := ^(^0 << uint32(32-ones)) + 1
 	subnetSize -= 3 //network, gateway and broadcast
 
 	//Skip the network address and gateway


### PR DESCRIPTION
There was a bug in the CNCI agent which was incorrectly computing the
number of ip addresses in a subnet.  The result being that it was
impossible to ssh into the last instance in a subnet.

Fixes: https://github.com/ciao-project/ciao/issues/1615

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>