### PR TITLE
workload_bat: switch to use bat.GetComputeNodes()

### DIFF
--- a/_release/bat/workload_bat/workload_bat_test.go
+++ b/_release/bat/workload_bat/workload_bat_test.go
@@ -376,23 +376,17 @@ func TestCreateUnschedulableHostnameWorkload(t *testing.T) {
 }
 
 func getSchedulableNodeDetails(ctx context.Context) (string, string, error) {
-	nodeData := []struct {
-		NodeID   string `json:"id"`
-		Hostname string `json:"hostname"`
-	}{}
-
-	args := []string{"node", "list", "--compute", "-f", "{{ tojson . }}"}
-	err := bat.RunCIAOCLIAsAdminJS(ctx, "", args, &nodeData)
-
+	nodes, err := bat.GetComputeNodes(ctx)
 	if err != nil {
 		return "", "", err
 	}
 
-	if len(nodeData) == 0 {
-		return "", "", errors.New("No nodes available")
+	for _, node := range nodes {
+		return node.ID, node.Hostname, nil
 	}
 
-	return nodeData[0].NodeID, nodeData[0].Hostname, nil
+	return "", "", errors.New("No nodes available")
+
 }
 
 // Check that scheduling by requirement works if the workload

--- a/bat/compute.go
+++ b/bat/compute.go
@@ -100,6 +100,7 @@ type NodeStatus struct {
 	TotalRunningInstances int       `json:"total_running_instances"`
 	TotalPendingInstances int       `json:"total_pending_instances"`
 	TotalPausedInstances  int       `json:"total_paused_instances"`
+	Hostname              string    `json:"hostname"`
 }
 
 func checkEnv(vars []string) error {


### PR DESCRIPTION
Originally workload_bat called ciao-cli directly to get the details of
compute nodes in order to get hostname for scheduling. Instead switch to
use bat.GetComputeNodes() after adding the hostname to the
datastructure.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>