### PR TITLE
qemu: add function to hotplug CPUs

### DIFF
--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -736,3 +736,18 @@ func (q *QMP) ExecutePCIVFIODeviceAdd(ctx context.Context, devID, bdf, addr, bus
 	}
 	return q.executeCommand(ctx, "device_add", args, nil)
 }
+
+// ExecuteCPUDeviceAdd adds a CPU to a QEMU instance using the device_add command.
+// driver is the CPU model, cpuID must be a unique ID to identify the CPU, socketID is the socket number within
+// node/board the CPU belongs to, coreID is the core number within socket the CPU belongs to, threadID is the
+// thread number within core the CPU belongs to.
+func (q *QMP) ExecuteCPUDeviceAdd(ctx context.Context, driver, cpuID, socketID, coreID, threadID string) error {
+	args := map[string]interface{}{
+		"driver":    driver,
+		"id":        cpuID,
+		"socket-id": socketID,
+		"core-id":   coreID,
+		"thread-id": threadID,
+	}
+	return q.executeCommand(ctx, "device_add", args, nil)
+}

--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -810,3 +810,25 @@ func TestQMPPCIDeviceAdd(t *testing.T) {
 	q.Shutdown()
 	<-disconnectedCh
 }
+
+// Checks that CPU are correctly added using device_add
+func TestQMPCPUDeviceAdd(t *testing.T) {
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	buf.AddCommand("device_add", nil, "return", nil)
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+	driver := "qemu64-x86_64-cpu"
+	cpuID := "cpu-0"
+	socketID := "0"
+	coreID := "1"
+	threadID := "0"
+	err := q.ExecuteCPUDeviceAdd(context.Background(), driver, cpuID, socketID, coreID, threadID)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	q.Shutdown()
+	<-disconnectedCh
+}

--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -75,7 +76,7 @@ type qmpTestEvent struct {
 
 type qmpTestResult struct {
 	result string
-	data   map[string]interface{}
+	data   interface{}
 }
 
 type qmpTestCommandBuffer struct {
@@ -132,11 +133,8 @@ func (b *qmpTestCommandBuffer) startEventLoop(wg *sync.WaitGroup) {
 }
 
 func (b *qmpTestCommandBuffer) AddCommand(name string, args map[string]interface{},
-	result string, data map[string]interface{}) {
+	result string, data interface{}) {
 	b.cmds = append(b.cmds, qmpTestCommand{name, args})
-	if data == nil {
-		data = make(map[string]interface{})
-	}
 	b.results = append(b.results, qmpTestResult{result, data})
 }
 
@@ -828,6 +826,40 @@ func TestQMPCPUDeviceAdd(t *testing.T) {
 	err := q.ExecuteCPUDeviceAdd(context.Background(), driver, cpuID, socketID, coreID, threadID)
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
+	}
+	q.Shutdown()
+	<-disconnectedCh
+}
+
+// Checks that hotpluggable CPUs are listed correctly
+func TestQMPExecuteQueryHotpluggableCPUs(t *testing.T) {
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	hotCPU := HotpluggableCPU{
+		Type:       "host-x86",
+		VcpusCount: 5,
+		Properties: CPUProperties{
+			Node:   1,
+			Socket: 3,
+			Core:   2,
+			Thread: 4,
+		},
+		QOMPath: "/abc/123/rgb",
+	}
+	buf.AddCommand("query-hotpluggable-cpus", nil, "return", []interface{}{hotCPU})
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+	hotCPUs, err := q.ExecuteQueryHotpluggableCPUs(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v\n", err)
+	}
+	if len(hotCPUs) != 1 {
+		t.Fatalf("Expected hot CPUs length equals to 1\n")
+	}
+	if reflect.DeepEqual(hotCPUs[0], hotCPU) == false {
+		t.Fatalf("Expected %v equals to %v\n", hotCPUs[0], hotCPU)
 	}
 	q.Shutdown()
 	<-disconnectedCh


### PR DESCRIPTION
This patch adds a new function to hot add CPUs in a QEMU instance

Signed-off-by: Julio Montes <julio.montes@intel.com>