### PR TITLE
Remove node status API and command

### DIFF
--- a/_release/bat/base_bat/base_bat_test.go
+++ b/_release/bat/base_bat/base_bat_test.go
@@ -110,29 +110,6 @@ func TestListComputeNodes(t *testing.T) {
 	}
 }
 
-// Confirm that the cluster is ready
-//
-// Retrieve the cluster status.
-//
-// Cluster status is retrieved successfully, the cluster contains more than one
-// node and all nodes are ready.
-func TestGetClusterStatus(t *testing.T) {
-	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
-	status, err := bat.GetClusterStatus(ctx)
-	cancelFunc()
-	if err != nil {
-		t.Fatalf("Failed to retrieve cluster status : %v", err)
-	}
-
-	if status.TotalNodes == 0 {
-		t.Fatalf("Cluster has no nodes")
-	}
-
-	if status.TotalNodes != status.TotalNodesReady {
-		t.Fatalf("Some nodes in the cluster are not ready")
-	}
-}
-
 // Get all available workloads
 //
 // TestGetWorkloads calls ciao-cli workload list

--- a/bat/compute.go
+++ b/bat/compute.go
@@ -671,21 +671,6 @@ func GetNetworkNodes(ctx context.Context) (map[string]*NodeStatus, error) {
 	return getNodes(ctx, args)
 }
 
-// GetClusterStatus returns the status of the ciao cluster. The information is
-// retrieved by calling ciao-cli node status. An error will be returned if the
-// following environment variables are not set; CIAO_ADMIN_CLIENT_CERT_FILE,
-// CIAO_CONTROLLER.
-func GetClusterStatus(ctx context.Context) (*ClusterStatus, error) {
-	var cs *ClusterStatus
-	args := []string{"node", "status", "-f", "{{tojson .}}"}
-	err := RunCIAOCLIAsAdminJS(ctx, "", args, &cs)
-	if err != nil {
-		return nil, err
-	}
-
-	return cs, nil
-}
-
 // Evacuate evacuates a given node of a ciao cluster.  An error will be returned
 // if the following environment variables are not set; CIAO_ADMIN_CLIENT_CERT_FILE,
 // CIAO_CONTROLLER.

--- a/ciao-cli/node.go
+++ b/ciao-cli/node.go
@@ -31,7 +31,6 @@ import (
 var nodeCommand = &command{
 	SubCommands: map[string]subCommand{
 		"list":     new(nodeListCommand),
-		"status":   new(nodeStatusCommand),
 		"show":     new(nodeShowCommand),
 		"evacuate": new(nodeEvacuateCommand),
 		"restore":  new(nodeRestoreCommand),
@@ -197,49 +196,6 @@ func listCNCINodes(t *template.Template) error {
 			fmt.Printf("\t\t%s\n", subnet.Subnet)
 		}
 	}
-	return nil
-}
-
-type nodeStatusCommand struct {
-	Flag     flag.FlagSet
-	template string
-}
-
-func (cmd *nodeStatusCommand) usage(...string) {
-	fmt.Fprintf(os.Stderr, `usage: ciao-cli [options] node status
-
-Show cluster status
-`)
-	cmd.Flag.PrintDefaults()
-	fmt.Fprintf(os.Stderr, "\n%s",
-		tfortools.GenerateUsageDecorated("f", types.CiaoClusterStatus{}.Status, nil))
-	os.Exit(2)
-}
-
-func (cmd *nodeStatusCommand) parseArgs(args []string) []string {
-	cmd.Flag.StringVar(&cmd.template, "f", "", "Template used to format output")
-	cmd.Flag.Usage = func() { cmd.usage() }
-	cmd.Flag.Parse(args)
-	return cmd.Flag.Args()
-}
-
-func (cmd *nodeStatusCommand) run(args []string) error {
-	status, err := c.GetNodeSummary()
-	if err != nil {
-		return errors.Wrap(err, "Error getting node summary")
-	}
-
-	if cmd.template != "" {
-		return tfortools.OutputToTemplate(os.Stdout, "node-status", cmd.template,
-			&status.Status, nil)
-	}
-
-	fmt.Printf("Total Nodes %d\n", status.Status.TotalNodes)
-	fmt.Printf("\tReady %d\n", status.Status.TotalNodesReady)
-	fmt.Printf("\tFull %d\n", status.Status.TotalNodesFull)
-	fmt.Printf("\tOffline %d\n", status.Status.TotalNodesOffline)
-	fmt.Printf("\tMaintenance %d\n", status.Status.TotalNodesMaintenance)
-
 	return nil
 }
 

--- a/ciao-controller/api.go
+++ b/ciao-controller/api.go
@@ -457,29 +457,6 @@ func listNodes(c *controller, w http.ResponseWriter, r *http.Request) (APIRespon
 	return listSubsetOfNodes(c, w, r, ssntp.UNKNOWN)
 }
 
-func nodesSummary(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
-	var nodesStatus types.CiaoClusterStatus
-
-	computeNodes := c.ds.GetNodeLastStats()
-
-	glog.V(2).Infof("nodesSummary %d nodes", len(computeNodes.Nodes))
-
-	nodesStatus.Status.TotalNodes = len(computeNodes.Nodes)
-	for _, node := range computeNodes.Nodes {
-		if node.Status == ssntp.READY.String() {
-			nodesStatus.Status.TotalNodesReady++
-		} else if node.Status == ssntp.FULL.String() {
-			nodesStatus.Status.TotalNodesFull++
-		} else if node.Status == ssntp.OFFLINE.String() {
-			nodesStatus.Status.TotalNodesOffline++
-		} else if node.Status == ssntp.MAINTENANCE.String() {
-			nodesStatus.Status.TotalNodesMaintenance++
-		}
-	}
-
-	return APIResponse{http.StatusOK, nodesStatus}, nil
-}
-
 func listNodeServers(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	vars := mux.Vars(r)
 	nodeID := vars["node"]

--- a/ciao-controller/compute_test.go
+++ b/ciao-controller/compute_test.go
@@ -726,48 +726,6 @@ func TestListNodes(t *testing.T) {
 	testListNodes(t, http.StatusOK, true)
 }
 
-func testNodeSummary(t *testing.T, httpExpectedStatus int, validToken bool) {
-	var expected types.CiaoClusterStatus
-
-	computeNodes := ctl.ds.GetNodeLastStats()
-
-	expected.Status.TotalNodes = len(computeNodes.Nodes)
-	for _, node := range computeNodes.Nodes {
-		if node.Status == ssntp.READY.String() {
-			expected.Status.TotalNodesReady++
-		} else if node.Status == ssntp.FULL.String() {
-			expected.Status.TotalNodesFull++
-		} else if node.Status == ssntp.OFFLINE.String() {
-			expected.Status.TotalNodesOffline++
-		} else if node.Status == ssntp.MAINTENANCE.String() {
-			expected.Status.TotalNodesMaintenance++
-		}
-	}
-
-	url := testutil.ComputeURL + "/v2.1/nodes/summary"
-
-	body := testHTTPRequest(t, "GET", url, httpExpectedStatus, nil, validToken)
-	// stop evaluating in case the scenario is InvalidToken
-	if httpExpectedStatus == 401 {
-		return
-	}
-
-	var result types.CiaoClusterStatus
-
-	err := json.Unmarshal(body, &result)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if reflect.DeepEqual(expected, result) == false {
-		t.Fatalf("expected: \n%+v\n result: \n%+v\n", expected, result)
-	}
-}
-
-func TestNodeSummary(t *testing.T) {
-	testNodeSummary(t, http.StatusOK, true)
-}
-
 func testListCNCIs(t *testing.T, httpExpectedStatus int, validToken bool) {
 	var expected types.CiaoCNCIs
 

--- a/ciao-controller/legacy_api.go
+++ b/ciao-controller/legacy_api.go
@@ -107,10 +107,6 @@ func legacyListNetworkNodes(c *controller, w http.ResponseWriter, r *http.Reques
 	return listNetworkNodes(c, w, r)
 }
 
-func legacyNodesSummary(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
-	return nodesSummary(c, w, r)
-}
-
 func legacyListNodeServers(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	return listNodeServers(c, w, r)
 }
@@ -155,8 +151,6 @@ func legacyComputeRoutes(ctl *controller, r *mux.Router) *mux.Router {
 
 	r.Handle("/v2.1/nodes",
 		legacyAPIHandler{ctl, legacyListNodes, true}).Methods("GET")
-	r.Handle("/v2.1/nodes/summary",
-		legacyAPIHandler{ctl, legacyNodesSummary, true}).Methods("GET")
 	r.Handle("/v2.1/nodes/{node}/servers/detail",
 		legacyAPIHandler{ctl, legacyListNodeServers, true}).Methods("GET")
 	r.Handle("/v2.1/nodes/compute",

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -461,19 +461,6 @@ func NewCiaoServersStats() (servers CiaoServersStats) {
 	return
 }
 
-// CiaoClusterStatus represents the unmarshalled version of the contents of a
-// v2.1/nodes/summary response.  It contains information about the nodes that
-// make up a ciao cluster.
-type CiaoClusterStatus struct {
-	Status struct {
-		TotalNodes            int `json:"total_nodes"`
-		TotalNodesReady       int `json:"total_nodes_ready"`
-		TotalNodesFull        int `json:"total_nodes_full"`
-		TotalNodesOffline     int `json:"total_nodes_offline"`
-		TotalNodesMaintenance int `json:"total_nodes_maintenance"`
-	} `json:"cluster"`
-}
-
 // CNCIDetail stores the IPv4 for a CNCI Agent.
 type CNCIDetail struct {
 	IPv4 string `json:"IPv4"`

--- a/client/legacy.go
+++ b/client/legacy.go
@@ -105,16 +105,6 @@ func (client *Client) ListCNCIs() (types.CiaoCNCIs, error) {
 	return nodes, err
 }
 
-// GetNodeSummary returns summary information about the cluster
-func (client *Client) GetNodeSummary() (types.CiaoClusterStatus, error) {
-	var status types.CiaoClusterStatus
-
-	url := client.buildComputeURL("nodes/summary")
-	err := client.getResource(url, "", nil, &status)
-
-	return status, err
-}
-
 // GetCNCI returns information about a CNCI
 func (client *Client) GetCNCI(cnciID string) (types.CiaoCNCI, error) {
 	var cnci types.CiaoCNCI


### PR DESCRIPTION
Remove legacy API for node summary and "ciao-cli node status" command that uses it along with BAT testing functionality relating to it.