### PR TITLE
3rd party: Revendor tfortools to v0.2.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -56,7 +56,7 @@
 	},
 	"github.com/intel/tfortools": {
 		"url": "https://github.com/intel/tfortools.git",
-		"version": "v0.1.0",
+		"version": "v0.2.0",
 		"license": "Apache v2.0"
 	},
 	"github.com/mattn/go-sqlite3": {

--- a/vendor/github.com/intel/tfortools/defaults.go
+++ b/vendor/github.com/intel/tfortools/defaults.go
@@ -26,12 +26,17 @@ var funcMap = template.FuncMap{
 	"filterFolded":    filterByFolded,
 	"filterRegexp":    filterByRegexp,
 	"tojson":          toJSON,
+	"tocsv":           toCSV,
 	"select":          selectField,
 	"selectalt":       selectFieldAlt,
 	"table":           table,
 	"tablealt":        tableAlt,
 	"tablex":          tablex,
 	"tablexalt":       tablexAlt,
+	"htable":          htable,
+	"htablealt":       htableAlt,
+	"htablex":         htablex,
+	"htablexalt":      htablexAlt,
 	"cols":            cols,
 	"sort":            sortSlice,
 	"rows":            rows,
@@ -40,6 +45,7 @@ var funcMap = template.FuncMap{
 	"describe":        describe,
 	"promote":         promote,
 	"sliceof":         sliceof,
+	"totable":         toTable,
 }
 
 var funcHelpSlice = []funcHelpInfo{
@@ -50,12 +56,17 @@ var funcHelpSlice = []funcHelpInfo{
 	{"filterFolded", helpFilterFolded, helpFilterFoldedIndex},
 	{"filterRegexp", helpFilterRegexp, helpFilterRegexpIndex},
 	{"tojson", helpToJSON, helpToJSONIndex},
+	{"tocsv", helpToCSV, helpToCSVIndex},
 	{"select", helpSelect, helpSelectIndex},
 	{"selectalt", helpSelectAlt, helpSelectAltIndex},
 	{"table", helpTable, helpTableIndex},
 	{"tablealt", helpTableAlt, helpTableAltIndex},
 	{"tablex", helpTableX, helpTableXIndex},
 	{"tablexalt", helpTableXAlt, helpTableXAltIndex},
+	{"htable", helpHTable, helpHTableIndex},
+	{"htablealt", helpHTableAlt, helpHTableAltIndex},
+	{"htablex", helpHTableX, helpHTableXIndex},
+	{"htablexalt", helpHTableXAlt, helpHTableXAltIndex},
 	{"cols", helpCols, helpColsIndex},
 	{"sort", helpSort, helpSortIndex},
 	{"rows", helpRows, helpRowsIndex},
@@ -64,6 +75,7 @@ var funcHelpSlice = []funcHelpInfo{
 	{"describe", helpDescribe, helpDescribeIndex},
 	{"promote", helpPromote, helpPromoteIndex},
 	{"sliceof", helpSliceof, helpSliceofIndex},
+	{"totable", helpToTable, helpToTableIndex},
 }
 
 func getFuncMap(cfg *Config) template.FuncMap {

--- a/vendor/github.com/intel/tfortools/funcs.go
+++ b/vendor/github.com/intel/tfortools/funcs.go
@@ -18,14 +18,18 @@ package tfortools
 
 import (
 	"bytes"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"reflect"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"text/template"
+	"unicode"
+	"unicode/utf8"
 )
 
 type tableHeading struct {
@@ -337,6 +341,54 @@ func toJSON(obj interface{}) string {
 	return string(b)
 }
 
+func toCSV(obj interface{}, skipHeader ...bool) string {
+	var data [][]string
+	var buf bytes.Buffer
+
+	data, ok := obj.([][]string)
+	if ok {
+		_ = csv.NewWriter(&buf).WriteAll(data)
+		return buf.String()
+	}
+
+	assertCollectionOfStructs("toCSV", reflect.ValueOf(obj))
+	v := reflect.ValueOf(obj)
+	data = make([][]string, 0, v.Len()+1)
+	if len(skipHeader) == 0 || !skipHeader[0] {
+		styp := v.Type().Elem()
+		if styp.Kind() == reflect.Ptr {
+			styp = styp.Elem()
+		}
+		var row []string
+		for i := 0; i < styp.NumField(); i++ {
+			field := styp.Field(i)
+			if field.PkgPath != "" {
+				continue
+			}
+			row = append(row, field.Name)
+		}
+		data = append(data, row)
+	}
+	for i := 0; i < v.Len(); i++ {
+		var row []string
+		s := v.Index(i)
+		if s.Kind() == reflect.Ptr {
+			s = s.Elem()
+		}
+		for j := 0; j < s.NumField(); j++ {
+			field := s.Field(j)
+			if s.Type().Field(j).PkgPath != "" {
+				continue
+			}
+			row = append(row, fmt.Sprintf("%v", field.Interface()))
+		}
+		data = append(data, row)
+	}
+
+	_ = csv.NewWriter(&buf).WriteAll(data)
+	return buf.String()
+}
+
 func assertCollectionOfStructs(fnName string, v reflect.Value) {
 	typ := v.Type()
 	kind := typ.Kind()
@@ -398,6 +450,29 @@ func createTable(v reflect.Value, minWidth, tabWidth, padding int,
 	return b.String()
 }
 
+func createHTable(v reflect.Value, minWidth, tabWidth, padding int,
+	format string, headings []tableHeading) string {
+	var b bytes.Buffer
+	w := tabwriter.NewWriter(&b, minWidth, tabWidth, padding, ' ', 0)
+	for i := 0; i < v.Len(); i++ {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		for _, h := range headings {
+			fmt.Fprintf(w, "%s:\t", h.name)
+			el := v.Index(i)
+			if el.Kind() == reflect.Ptr {
+				el = el.Elem()
+			}
+			fmt.Fprintf(w, format+"\t", el.Field(h.index).Interface())
+			fmt.Fprintln(w)
+		}
+	}
+	_ = w.Flush()
+
+	return b.String()
+}
+
 func table(obj interface{}) string {
 	val := getValue(obj)
 	return createTable(val, 8, 8, 1, "%v", getTableHeadings("table", val))
@@ -408,26 +483,50 @@ func tableAlt(obj interface{}) string {
 	return createTable(val, 8, 8, 1, "%#v", getTableHeadings("table", val))
 }
 
-func tablexBase(obj interface{}, minWidth, tabWidth, padding int,
-	format string, userHeadings ...string) string {
-	val := getValue(obj)
-	headings := getTableHeadings("tablex", val)
+func xHeadings(fnName string, val reflect.Value, userHeadings []string) []tableHeading {
+	headings := getTableHeadings(fnName, val)
 	if len(headings) < len(userHeadings) {
-		fatalf("tablex", "Too many headings specified.  Max permitted %d got %d",
+		fatalf(fnName, "Too many headings specified.  Max permitted %d got %d",
 			len(headings), len(userHeadings))
 	}
 	for i := range userHeadings {
 		headings[i].name = userHeadings[i]
 	}
-	return createTable(val, minWidth, tabWidth, padding, format, headings)
+	return headings
 }
 
 func tablex(obj interface{}, minWidth, tabWidth, padding int, userHeadings ...string) string {
-	return tablexBase(obj, minWidth, tabWidth, padding, "%v", userHeadings...)
+	val := getValue(obj)
+	headings := xHeadings("tablex", val, userHeadings)
+	return createTable(val, minWidth, tabWidth, padding, "%v", headings)
 }
 
 func tablexAlt(obj interface{}, minWidth, tabWidth, padding int, userHeadings ...string) string {
-	return tablexBase(obj, minWidth, tabWidth, padding, "%#v", userHeadings...)
+	val := getValue(obj)
+	headings := xHeadings("tablexalt", val, userHeadings)
+	return createTable(val, minWidth, tabWidth, padding, "%#v", headings)
+}
+
+func htable(obj interface{}) string {
+	val := getValue(obj)
+	return createHTable(val, 8, 8, 1, "%v", getTableHeadings("htable", val))
+}
+
+func htableAlt(obj interface{}) string {
+	val := getValue(obj)
+	return createHTable(val, 8, 8, 1, "%#v", getTableHeadings("htablealt", val))
+}
+
+func htablex(obj interface{}, minWidth, tabWidth, padding int, userHeadings ...string) string {
+	val := getValue(obj)
+	headings := xHeadings("htablex", val, userHeadings)
+	return createHTable(val, minWidth, tabWidth, padding, "%v", headings)
+}
+
+func htablexAlt(obj interface{}, minWidth, tabWidth, padding int, userHeadings ...string) string {
+	val := getValue(obj)
+	headings := xHeadings("htablexalt", val, userHeadings)
+	return createHTable(val, minWidth, tabWidth, padding, "%#v", headings)
 }
 
 func cols(obj interface{}, fields ...string) interface{} {
@@ -622,4 +721,92 @@ func describe(obj interface{}) string {
 	var buf bytes.Buffer
 	generateIndentedUsage(&buf, obj)
 	return buf.String()
+}
+
+func sanitizeName(name string) string {
+	var buf bytes.Buffer
+
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return name
+	}
+
+	rune, len := utf8.DecodeRuneInString(name)
+	if !unicode.IsLetter(rune) {
+		_, _ = buf.WriteRune('X')
+	} else {
+		_, _ = buf.WriteRune(unicode.ToTitle(rune))
+		name = name[len:]
+	}
+
+	for _, rune := range name {
+		if !unicode.IsLetter(rune) && !unicode.IsDigit(rune) {
+			rune = '_'
+		}
+		_, _ = buf.WriteRune(rune)
+	}
+
+	return buf.String()
+}
+
+func guessType(v string) reflect.Type {
+	if p, err := strconv.Atoi(v); err == nil {
+		return reflect.TypeOf(p)
+	}
+	if p, err := strconv.ParseFloat(v, 64); err == nil {
+		return reflect.TypeOf(p)
+	}
+	return reflect.TypeOf("")
+}
+
+func toTable(data [][]string) interface{} {
+	defer func() {
+		err := recover()
+		if err != nil {
+			fatalf("promote", "Invalid use of toTable: %v", err)
+		}
+	}()
+
+	if len(data) < 2 {
+		panic("Expected at least two rows")
+	}
+
+	var fields []reflect.StructField
+	for _, f := range data[0] {
+		fields = append(fields, reflect.StructField{
+			Name: sanitizeName(f),
+		})
+	}
+
+	for i, v := range data[1] {
+		fields[i].Type = guessType(v)
+	}
+
+	sTyp := reflect.StructOf(fields)
+	newVal := reflect.MakeSlice(reflect.SliceOf(sTyp), len(data)-1, len(data)-1)
+	for i, row := range data[1:] {
+		sVal := reflect.New(sTyp)
+		for j, v := range row {
+			f := sVal.Elem().Field(j)
+			switch f.Kind() {
+			case reflect.Int:
+				num, err := strconv.Atoi(v)
+				if err != nil {
+					panic(fmt.Sprintf("integer expected found %s at (%d, %d)", v, j, i))
+				}
+				f.Set(reflect.ValueOf(num))
+			case reflect.Float64:
+				num, err := strconv.ParseFloat(v, 64)
+				if err != nil {
+					panic(fmt.Sprintf("float expected found %s at (%d, %d)", v, j, i))
+				}
+				f.Set(reflect.ValueOf(num))
+			default:
+				f.Set(reflect.ValueOf(v))
+			}
+		}
+		newVal.Index(i).Set(sVal.Elem())
+	}
+
+	return newVal.Interface()
 }

--- a/vendor/github.com/intel/tfortools/tfortools.go
+++ b/vendor/github.com/intel/tfortools/tfortools.go
@@ -84,12 +84,17 @@ const (
 	helpFilterFoldedIndex
 	helpFilterRegexpIndex
 	helpToJSONIndex
+	helpToCSVIndex
 	helpSelectIndex
 	helpSelectAltIndex
 	helpTableIndex
 	helpTableAltIndex
 	helpTableXIndex
 	helpTableXAltIndex
+	helpHTableIndex
+	helpHTableAltIndex
+	helpHTableXIndex
+	helpHTableXAltIndex
 	helpColsIndex
 	helpSortIndex
 	helpRowsIndex
@@ -98,6 +103,7 @@ const (
 	helpDescribeIndex
 	helpPromoteIndex
 	helpSliceofIndex
+	helpToTableIndex
 	helpIndexCount
 )
 
@@ -304,6 +310,31 @@ func OptToJSON(c *Config) {
 	c.funcHelp = append(c.funcHelp, funcHelpInfo{"tojson", helpToJSON, helpToJSONIndex})
 }
 
+const helpToCSV = `- 'tocsv' converts a [][]string or a slice of structs to csv format, e.g.,
+  {{tocsv .}}
+
+  'tocsv' takes an optional boolean parameter, which if true, omits the
+  first row containing the structure field name derived column headings.
+  This boolean parameter defaults to false and is ignored when operating
+  on a [][]string.
+`
+
+// OptToCSV indicates that the 'tocsv' function should be enabled.
+// 'tocsv' converts a [][]string or a slice of structs to csv format, e.g.,
+// {{tocsv .}}
+//
+// 'tocsv' takes an optional boolean parameter, which if true, omits the
+// first row containing the structure field name derived column headings.
+// This boolean parameter defaults to false and is ignored when operating
+// on a [][]string.
+func OptToCSV(c *Config) {
+	if _, ok := c.funcMap["tocsv"]; ok {
+		return
+	}
+	c.funcMap["tocsv"] = toCSV
+	c.funcHelp = append(c.funcHelp, funcHelpInfo{"tocsv", helpToCSV, helpToCSVIndex})
+}
+
 const helpSelect = `- 'select' operates on a slice of structs.  It outputs the value of a specified
   field for each struct on a new line , e.g.,
 
@@ -380,15 +411,15 @@ func OptTableAlt(c *Config) {
 
 const helpTableX = `- 'tablex' is similar to table but it allows the caller more control over the
   table's appearance.  Users can control the names of the headings and also set
-  the tab and column width.  'tablex' takes 3 or more parameters.  The first
+  the tab and column width.  'tablex' takes 4 or more parameters.  The first
   parameter is the slice of structs to output, the second is the minimum column
-  width, the third the tab width.  The fourth and subsequent parameters are the
-  names of the column headings.  The column headings are optional and the field
-  names of the structure will be used if they are absent.  Example of its usage
-  are:
+  width, the third the tab width  and the fourth is the padding.  The fifth and
+  subsequent parameters are the names of the column headings.  The column
+  headings are optional and the field names of the structure will be used if
+  they are absent.  Example of its usage are:
 
-  {{tablex . 12 8 "Column 1" "Column 2"}}
-  {{tablex . 8 8}}
+  {{tablex . 12 8 1 "Column 1" "Column 2"}}
+  {{tablex . 8 8 1}}
 `
 
 // OptTableX indicates that the 'tablex' function should be enabled. 'tablex' is
@@ -396,7 +427,7 @@ const helpTableX = `- 'tablex' is similar to table but it allows the caller more
 // appearance. Users can control the names of the headings and also set the tab
 // and column width. 'tablex' takes 4 or more parameters. The first parameter is
 // the slice of structs to output, the second is the minimum column width, the
-// third the tab width and the fourth is the padding. The fift and subsequent
+// third the tab width and the fourth is the padding. The fifth and subsequent
 // parameters are the names of the column headings. The column headings are
 // optional and the field names of the structure will be used if they are
 // absent. Example of its usage are:
@@ -423,6 +454,92 @@ func OptTableXAlt(c *Config) {
 	c.funcMap["tablexalt"] = tablexAlt
 	c.funcHelp = append(c.funcHelp,
 		funcHelpInfo{"tablexalt", helpTableXAlt, helpTableXAltIndex})
+}
+
+const helpHTable = `- 'htable' outputs each element of an array or a slice of structs
+  in its own two column table.  The values for the first column are taken from
+  the names of the structs' fields.  The second column contains the field values.
+  Hidden fields and fields of type channel are ignored. The tabwidth and minimum
+  column width are hardcoded to 8.  An example of htable's usage is
+
+  {{htable .}}
+`
+
+// OptHTable indicates that the 'htable' function should be enabled.
+// 'htable' outputs each element of an array or a slice of structs in its own
+// two column table.  The values for the first column are taken from
+// the names of the structs' fields.  The second column contains the field values.
+// Hidden fields and fields of type channel are ignored. The tabwidth and minimum
+// column width are hardcoded to 8.  An example of htable's usage is
+//
+//  {{htable .}}
+func OptHTable(c *Config) {
+	if _, ok := c.funcMap["htable"]; ok {
+		return
+	}
+	c.funcMap["htable"] = htable
+	c.funcHelp = append(c.funcHelp, funcHelpInfo{"htable", helpHTable, helpHTableIndex})
+}
+
+const helpHTableAlt = `- 'htablealt' Similar to htable except that objects are formatted using %#v
+`
+
+// OptHTableAlt indicates that the 'htablealt' function should be enabled.
+// 'htablealt' Similar to table except that objects are formatted using %#v
+func OptHTableAlt(c *Config) {
+	if _, ok := c.funcMap["htablealt"]; ok {
+		return
+	}
+	c.funcMap["htablealt"] = htableAlt
+	c.funcHelp = append(c.funcHelp,
+		funcHelpInfo{"htablealt", helpHTableAlt, helpHTableAltIndex})
+}
+
+const helpHTableX = `- 'htablex' is similar to htable but it allows the caller more control over the
+  tables' appearances.  Users can control the names displayed in the first column
+  and also set the tab and column width.  'htablex' takes 4 or more parameters.
+  The first parameter is the slice of structs to output, the second is the minimum
+  column width, the third the tab width  and the fourth is the padding.  The
+  fifth and subsequent parameters are the values displayed in the first column
+  of each table.  These first column values are optional and the field names of
+  the structures will be used if they are absent.  Example of its usage are:
+
+  {{htablex . 12 8 1 "Field 1" "Field 2"}}
+  {{htablex . 8 8 1}}
+`
+
+// OptHTableX indicates that the 'htablex' function should be enabled.  'htablex'
+// is similar to htable but it allows the caller more control over the
+// tables' appearances.  Users can control the names displayed in the first column
+// and also set the tab and column width.  'htablex' takes 4 or more parameters.
+// The first parameter is the slice of structs to output, the second is the minimum
+// column width, the third the tab width  and the fourth is the padding.  The
+// fifth and subsequent parameters are the values displayed in the first column of
+// each table.  These first column values are optional and the field names of the
+// structures will be used if they are absent.  Example of its usage are:
+//
+//  {{htablex . 12 8 1 "Field 1" "Field 2"}}
+//  {{htablex . 8 8 1}}
+func OptHTableX(c *Config) {
+	if _, ok := c.funcMap["htablex"]; ok {
+		return
+	}
+	c.funcMap["htablex"] = htablex
+	c.funcHelp = append(c.funcHelp, funcHelpInfo{"htablex", helpHTableX, helpHTableXIndex})
+}
+
+const helpHTableXAlt = `- 'htablexalt' Similar to htablex except that objects are formatted using %#v
+`
+
+// OptHTableXAlt indicates that the 'htablexalt' function should be enabled.
+// 'htablexalt' Similar to htablex except that objects are formatted using %#v
+func OptHTableXAlt(c *Config) {
+	if _, ok := c.funcMap["htablexalt"]; ok {
+		return
+	}
+	c.funcMap["htablexalt"] = htablexAlt
+	c.funcHelp = append(c.funcHelp,
+		funcHelpInfo{"htablexalt", helpHTableXAlt, helpHTableXAltIndex})
 }
 
 const helpCols = `- 'cols' can be used to extract certain columns from a table consisting of a
@@ -666,6 +783,33 @@ func OptSliceof(c *Config) {
 	}
 	c.funcMap["sliceof"] = sliceof
 	c.funcHelp = append(c.funcHelp, funcHelpInfo{"sliceof", helpSliceof, helpSliceofIndex})
+}
+
+const helpToTable = `- 'totable' converts a slice of a slice of strings into a slice of
+  structures.  The field names of the structures are taken from the values of
+  the first row in the slice.  The types of the fields are derived from the
+  values specified in the second row.  The input slice should be of length 2
+  or greater.  Data in columns in the second and subsequent rows should be
+  homogenous.  The elements of the first row should be unique and ideally be
+  valid exported variable names.  'totable' will try to sanitize the field
+  names, if they are not valid go identifiers.
+`
+
+// OptToTable indicates that the 'totable' function should be enabled. 'totable'
+// takes a slice of a slice of strings as an argument and returns a slice of
+// structures.  The field names of the structures are taken from the values of
+// the first row in the slice.  The types of the fields are derived from the
+// values specified in the second row.  The input slice should be of length 2
+// or greater.  Data in columns in the second and subsequent rows should be
+// homogenous.  The elements of the first row should be unique and ideally
+// be valid exported variable names.  'totable' will try to sanitize the field
+// names, if they are not valid go identifiers.
+func OptToTable(c *Config) {
+	if _, ok := c.funcMap["totable"]; ok {
+		return
+	}
+	c.funcMap["totable"] = toTable
+	c.funcHelp = append(c.funcHelp, funcHelpInfo{"totable", helpToTable, helpToTableIndex})
 }
 
 // NewConfig creates a new Config object that can be passed to other functions


### PR DESCRIPTION
This adds a number of new functions:

- tocsv outputs a collection of structs in CSV format
- totable converts a slice of a slice strings into a slice of structs
- htable, htablex, htablealt, htablexalt output slices of structs as a sequence of tables.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>