### PR TITLE
kubicle: Update default k8s version to 1.8.4

### DIFF
--- a/k8s/kubicle/kubicle.go
+++ b/k8s/kubicle/kubicle.go
@@ -100,7 +100,7 @@ func createFlags() (*options, error) {
 			diskGiB: 10,
 		},
 		workers:    1,
-		k8sVersion: "1.7.11",
+		k8sVersion: "1.8.4",
 	}
 
 	opts.user = os.Getenv("USER")


### PR DESCRIPTION
This commit updates the default version of k8s used by kubicle.  There was a
race condition in the old default version, that could cause kubeadm to fail
randomly.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>